### PR TITLE
chore: Rebrand to ai-pipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ai-cli
+# ai-pipe
 
 A lean CLI for calling LLMs from the terminal. Text in, text out.
 
@@ -10,7 +10,7 @@ Built on the [Vercel AI SDK](https://sdk.vercel.ai/) with [Bun](https://bun.sh/)
 - **Streaming by default** — tokens print as they arrive
 - **Pipe-friendly** — reads from stdin, writes to stdout, errors to stderr
 - **JSON output** — structured response with usage and finish reason
-- **Config files** — set defaults in `~/.ai-cli.json`
+- **Config files** — set defaults in `~/.ai-pipe.json`
 - **Shell completions** — bash, zsh, fish
 - **Standalone binary** — compile to a single executable with `bun build --compile`
 
@@ -33,36 +33,36 @@ export ANTHROPIC_API_KEY="sk-ant-..."
 export OPENROUTER_API_KEY="sk-or-..."
 ```
 
-Run `ai --providers` to see which keys are configured.
+Run `ai-pipe --providers` to see which keys are configured.
 
 ## Usage
 
 ```sh
 # Ask a question
-ai "explain monads in one sentence"
+ai-pipe "explain monads in one sentence"
 
 # Pipe content
-cat main.go | ai "review this code"
-echo "hello world" | ai "translate to French"
+cat main.go | ai-pipe "review this code"
+echo "hello world" | ai-pipe "translate to French"
 
 # Pick a provider and model
-ai -m anthropic/claude-sonnet-4-5 "write a haiku"
-ai -m google/gemini-2.5-flash "summarize this" < article.txt
+ai-pipe -m anthropic/claude-sonnet-4-5 "write a haiku"
+ai-pipe -m google/gemini-2.5-flash "summarize this" < article.txt
 
 # Set a system prompt
-ai -s "you are a senior Go developer" "review this PR" < diff.txt
+ai-pipe -s "you are a senior Go developer" "review this PR" < diff.txt
 
 # Get JSON output
-ai --json "what is 2+2"
+ai-pipe --json "what is 2+2"
 
 # Disable streaming
-ai --no-stream "list 3 colors"
+ai-pipe --no-stream "list 3 colors"
 
 # Adjust temperature
-ai -t 1.5 "write a creative story"
+ai-pipe -t 1.5 "write a creative story"
 
 # Limit output length
-ai --max-output-tokens 100 "explain quantum computing"
+ai-pipe --max-output-tokens 100 "explain quantum computing"
 ```
 
 If no `provider/` prefix is given, the model defaults to `openai`. If no `-m` flag is given, it defaults to `openai/gpt-4o`.
@@ -84,7 +84,7 @@ If no `provider/` prefix is given, the model defaults to `openai`. If no `-m` fl
 
 ## Config File
 
-Create `~/.ai-cli.json` to set defaults:
+Create `~/.ai-pipe.json` to set defaults:
 
 ```json
 {
@@ -104,7 +104,7 @@ API keys in the config file work as an alternative to environment variables. Env
 Use a custom config path with `-c`:
 
 ```sh
-ai -c ./my-config.json "hello"
+ai-pipe -c ./my-config.json "hello"
 ```
 
 CLI flags always override config file values.
@@ -113,13 +113,13 @@ CLI flags always override config file values.
 
 ```sh
 # bash — add to ~/.bashrc
-eval "$(ai --completions bash)"
+eval "$(ai-pipe --completions bash)"
 
 # zsh — add to ~/.zshrc
-eval "$(ai --completions zsh)"
+eval "$(ai-pipe --completions zsh)"
 
 # fish — save to completions dir
-ai --completions fish > ~/.config/fish/completions/ai.fish
+ai-pipe --completions fish > ~/.config/fish/completions/ai-pipe.fish
 ```
 
 ## JSON Output
@@ -142,13 +142,13 @@ Use `--json` to get structured output:
 Pipe into `jq` for further processing:
 
 ```sh
-ai --json "list 3 colors" | jq -r '.text'
+ai-pipe --json "list 3 colors" | jq -r '.text'
 ```
 
 ## Flags
 
 ```
-Usage: ai [options] [prompt...]
+Usage: ai-pipe [options] [prompt...]
 
 Options:
   -m, --model <model>          Model in provider/model-id format
@@ -186,7 +186,7 @@ Binaries are output to `dist/`.
 
 ```sh
 bun install
-bun test              # 158 tests across 6 files
+bun test              # 172 tests across 6 files
 bun run typecheck     # TypeScript type checking
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "ai-cli",
+  "name": "ai-pipe",
   "version": "1.0.0",
   "description": "A lean CLI for calling LLMs from the terminal. Text in, text out.",
   "module": "src/index.ts",
   "type": "module",
   "bin": {
-    "ai": "src/index.ts"
+    "ai-pipe": "src/index.ts"
   },
   "files": [
     "src",
@@ -15,11 +15,11 @@
   "scripts": {
     "start": "bun src/index.ts",
     "test": "bun test",
-    "build": "bun build src/index.ts --compile --outfile dist/ai",
-    "build:linux": "bun build src/index.ts --compile --target=bun-linux-x64 --outfile dist/ai-linux-x64",
-    "build:linux-arm": "bun build src/index.ts --compile --target=bun-linux-arm64 --outfile dist/ai-linux-arm64",
-    "build:mac": "bun build src/index.ts --compile --target=bun-darwin-arm64 --outfile dist/ai-darwin-arm64",
-    "build:mac-x64": "bun build src/index.ts --compile --target=bun-darwin-x64 --outfile dist/ai-darwin-x64",
+    "build": "bun build src/index.ts --compile --outfile dist/ai-pipe",
+    "build:linux": "bun build src/index.ts --compile --target=bun-linux-x64 --outfile dist/ai-pipe-linux-x64",
+    "build:linux-arm": "bun build src/index.ts --compile --target=bun-linux-arm64 --outfile dist/ai-pipe-linux-arm64",
+    "build:mac": "bun build src/index.ts --compile --target=bun-darwin-arm64 --outfile dist/ai-pipe-darwin-arm64",
+    "build:mac-x64": "bun build src/index.ts --compile --target=bun-darwin-x64 --outfile dist/ai-pipe-darwin-x64",
     "build:all": "bun run build:mac && bun run build:mac-x64 && bun run build:linux && bun run build:linux-arm",
     "typecheck": "tsc --noEmit"
   },

--- a/src/__tests__/cli.test.ts
+++ b/src/__tests__/cli.test.ts
@@ -43,13 +43,13 @@ async function runCLI(
 describe("CLI: help and version", () => {
   test("prints help with --help", async () => {
     const { stdout, exitCode } = await runCLI(["--help"]);
-    expect(stdout).toContain("Usage: ai");
+    expect(stdout).toContain("Usage: ai-pipe");
     expect(exitCode).toBe(0);
   });
 
   test("prints help with -h", async () => {
     const { stdout, exitCode } = await runCLI(["-h"]);
-    expect(stdout).toContain("Usage: ai");
+    expect(stdout).toContain("Usage: ai-pipe");
     expect(exitCode).toBe(0);
   });
 
@@ -286,20 +286,20 @@ describe("CLI: --providers flag", () => {
 describe("CLI: --completions flag", () => {
   test("generates bash completions", async () => {
     const { stdout, exitCode } = await runCLI(["--completions", "bash"]);
-    expect(stdout).toContain("_ai_completions");
+    expect(stdout).toContain("_ai_pipe_completions");
     expect(stdout).toContain("complete -F");
     expect(exitCode).toBe(0);
   });
 
   test("generates zsh completions", async () => {
     const { stdout, exitCode } = await runCLI(["--completions", "zsh"]);
-    expect(stdout).toContain("compdef _ai ai");
+    expect(stdout).toContain("compdef _ai_pipe ai-pipe");
     expect(exitCode).toBe(0);
   });
 
   test("generates fish completions", async () => {
     const { stdout, exitCode } = await runCLI(["--completions", "fish"]);
-    expect(stdout).toContain("complete -c ai");
+    expect(stdout).toContain("complete -c ai-pipe");
     expect(exitCode).toBe(0);
   });
 

--- a/src/__tests__/completions.test.ts
+++ b/src/__tests__/completions.test.ts
@@ -8,8 +8,8 @@ describe("generateCompletions", () => {
   describe("bash", () => {
     test("generates valid bash completions", () => {
       const result = generateCompletions("bash");
-      expect(result).toContain("_ai_completions");
-      expect(result).toContain("complete -F _ai_completions ai");
+      expect(result).toContain("_ai_pipe_completions");
+      expect(result).toContain("complete -F _ai_pipe_completions ai-pipe");
     });
 
     test("includes all flags", () => {
@@ -36,7 +36,7 @@ describe("generateCompletions", () => {
 
     test("includes install instructions", () => {
       const result = generateCompletions("bash");
-      expect(result).toContain('eval "$(ai --completions bash)"');
+      expect(result).toContain('eval "$(ai-pipe --completions bash)"');
     });
   });
 
@@ -45,7 +45,7 @@ describe("generateCompletions", () => {
   describe("zsh", () => {
     test("generates valid zsh completions", () => {
       const result = generateCompletions("zsh");
-      expect(result).toContain("compdef _ai ai");
+      expect(result).toContain("compdef _ai_pipe ai-pipe");
       expect(result).toContain("_arguments");
     });
 
@@ -58,7 +58,7 @@ describe("generateCompletions", () => {
 
     test("includes install instructions", () => {
       const result = generateCompletions("zsh");
-      expect(result).toContain('eval "$(ai --completions zsh)"');
+      expect(result).toContain('eval "$(ai-pipe --completions zsh)"');
     });
   });
 
@@ -67,7 +67,7 @@ describe("generateCompletions", () => {
   describe("fish", () => {
     test("generates valid fish completions", () => {
       const result = generateCompletions("fish");
-      expect(result).toContain("complete -c ai");
+      expect(result).toContain("complete -c ai-pipe");
     });
 
     test("includes all flags", () => {
@@ -94,7 +94,7 @@ describe("generateCompletions", () => {
 
     test("includes install instructions", () => {
       const result = generateCompletions("fish");
-      expect(result).toContain("~/.config/fish/completions/ai.fish");
+      expect(result).toContain("~/.config/fish/completions/ai-pipe.fish");
     });
   });
 });

--- a/src/completions.ts
+++ b/src/completions.ts
@@ -19,9 +19,9 @@ export function generateCompletions(shell: string): string {
 }
 
 function bash(): string {
-  return `# ai-cli bash completions
-# Add to ~/.bashrc: eval "$(ai --completions bash)"
-_ai_completions() {
+  return `# ai-pipe bash completions
+# Add to ~/.bashrc: eval "$(ai-pipe --completions bash)"
+_ai_pipe_completions() {
   local cur prev opts providers
   COMPREPLY=()
   cur="\${COMP_WORDS[COMP_CWORD]}"
@@ -57,13 +57,13 @@ _ai_completions() {
     return 0
   fi
 }
-complete -F _ai_completions ai`;
+complete -F _ai_pipe_completions ai-pipe`;
 }
 
 function zsh(): string {
-  return `# ai-cli zsh completions
-# Add to ~/.zshrc: eval "$(ai --completions zsh)"
-_ai() {
+  return `# ai-pipe zsh completions
+# Add to ~/.zshrc: eval "$(ai-pipe --completions zsh)"
+_ai_pipe() {
   local -a providers
   providers=(${SUPPORTED_PROVIDERS.map((p) => `'${p}/'`).join(" ")})
 
@@ -88,21 +88,21 @@ _ai() {
       ;;
   esac
 }
-compdef _ai ai`;
+compdef _ai_pipe ai-pipe`;
 }
 
 function fish(): string {
-  return `# ai-cli fish completions
-# Add to ~/.config/fish/completions/ai.fish
-complete -c ai -s m -l model -d 'Model in provider/model-id format' -x -a '${SUPPORTED_PROVIDERS.map((p) => `${p}/`).join(" ")}'
-complete -c ai -s s -l system -d 'System prompt' -x
-complete -c ai -s j -l json -d 'Output full JSON response object'
-complete -c ai -l no-stream -d 'Wait for full response, then print'
-complete -c ai -s t -l temperature -d 'Sampling temperature (0-2)' -x
-complete -c ai -l max-output-tokens -d 'Maximum tokens to generate' -x
-complete -c ai -s c -l config -d 'Path to config file' -r -F
-complete -c ai -l providers -d 'List supported providers'
-complete -c ai -l completions -d 'Generate shell completions' -x -a 'bash zsh fish'
-complete -c ai -s V -l version -d 'Print version'
-complete -c ai -s h -l help -d 'Print help'`;
+  return `# ai-pipe fish completions
+# Add to ~/.config/fish/completions/ai-pipe.fish
+complete -c ai-pipe -s m -l model -d 'Model in provider/model-id format' -x -a '${SUPPORTED_PROVIDERS.map((p) => `${p}/`).join(" ")}'
+complete -c ai-pipe -s s -l system -d 'System prompt' -x
+complete -c ai-pipe -s j -l json -d 'Output full JSON response object'
+complete -c ai-pipe -l no-stream -d 'Wait for full response, then print'
+complete -c ai-pipe -s t -l temperature -d 'Sampling temperature (0-2)' -x
+complete -c ai-pipe -l max-output-tokens -d 'Maximum tokens to generate' -x
+complete -c ai-pipe -s c -l config -d 'Path to config file' -r -F
+complete -c ai-pipe -l providers -d 'List supported providers'
+complete -c ai-pipe -l completions -d 'Generate shell completions' -x -a 'bash zsh fish'
+complete -c ai-pipe -s V -l version -d 'Print version'
+complete -c ai-pipe -s h -l help -d 'Print help'`;
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -18,7 +18,7 @@ export const ConfigSchema = z.object({
 
 export type Config = z.infer<typeof ConfigSchema>;
 
-const DEFAULT_CONFIG_PATH = join(homedir(), ".ai-cli.json");
+const DEFAULT_CONFIG_PATH = join(homedir(), ".ai-pipe.json");
 
 export async function loadConfig(configPath?: string): Promise<Config> {
   const path = configPath ?? DEFAULT_CONFIG_PATH;

--- a/src/index.ts
+++ b/src/index.ts
@@ -189,7 +189,7 @@ async function run(promptArgs: string[], rawOpts: Record<string, unknown>) {
 // Only run CLI when executed directly, not when imported
 if (import.meta.main) {
   program
-    .name("ai")
+    .name("ai-pipe")
     .description("A lean CLI for calling LLMs from the terminal.")
     .version(pkg.version)
     .argument("[prompt...]", "Prompt text. Multiple words are joined.")


### PR DESCRIPTION
## Summary
- Rename package from `ai-cli` to `ai-pipe` (available on npm)
- Update binary name from `ai` to `ai-pipe`
- Update config path from `~/.ai-cli.json` to `~/.ai-pipe.json`
- Update all shell completions (bash, zsh, fish) to use `ai-pipe`
- Update all references in README, tests, and source

## Test plan
- [x] `bun test` — 172 tests pass
- [x] `bun run typecheck` — clean
- [x] Verified `ai-pipe` is available on npm