### PR TITLE
feat: Add ai as binary alias

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "module": "src/index.ts",
   "type": "module",
   "bin": {
-    "ai-pipe": "src/index.ts"
+    "ai-pipe": "src/index.ts",
+    "ai": "src/index.ts"
   },
   "files": [
     "src",


### PR DESCRIPTION
## Summary
- Add `ai` as a second bin entry alongside `ai-pipe` so users can use either command
- Stacks on #8 (rebrand)

## Test plan
- [x] `bun test` — 172 tests pass