### PR TITLE
✨ Migrate config to directory structure + npm publishing prep

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Built on the [Vercel AI SDK](https://sdk.vercel.ai/) with [Bun](https://bun.sh/)
 - **Streaming by default** — tokens print as they arrive
 - **Pipe-friendly** — reads from stdin, writes to stdout, errors to stderr
 - **JSON output** — structured response with usage and finish reason
-- **Config files** — set defaults in `~/.ai-pipe.json`
+- **Config directory** — set defaults in `~/.ai-pipe/`
 - **Shell completions** — bash, zsh, fish
 - **Standalone binary** — compile to a single executable with `bun build --compile`
 
@@ -100,32 +100,39 @@ If no `provider/` prefix is given, the model defaults to `openai`. If no `-m` fl
 | ollama | `OLLAMA_HOST` | `ollama/llama3` |
 | huggingface | `HF_TOKEN` | `huggingface/meta-llama/Llama-3.3-70b-Instruct` |
 
-## Config File
+## Config Directory
 
-Create `~/.ai-pipe.json` to set defaults:
+Create `~/.ai-pipe/` with two optional files:
+
+**`~/.ai-pipe/config.json`** — settings:
 
 ```json
 {
   "model": "anthropic/claude-sonnet-4-5",
   "system": "Be concise.",
   "temperature": 0.7,
-  "maxOutputTokens": 1000,
-  "apiKeys": {
-    "anthropic": "sk-ant-...",
-    "openai": "sk-..."
-  }
+  "maxOutputTokens": 1000
 }
 ```
 
-API keys in the config file work as an alternative to environment variables. Environment variables always take precedence over config file keys.
+**`~/.ai-pipe/apiKeys.json`** — API keys:
 
-Use a custom config path with `-c`:
-
-```sh
-ai-pipe -c ./my-config.json "hello"
+```json
+{
+  "anthropic": "sk-ant-...",
+  "openai": "sk-..."
+}
 ```
 
-CLI flags always override config file values.
+API keys in `apiKeys.json` work as an alternative to environment variables. Environment variables always take precedence.
+
+Use a custom config directory with `-c`:
+
+```sh
+ai-pipe -c ./my-config-dir "hello"
+```
+
+CLI flags always override config values.
 
 ## Shell Completions
 
@@ -175,7 +182,7 @@ Options:
   --no-stream                  Wait for full response, then print
   -t, --temperature <n>        Sampling temperature (0-2)
   --max-output-tokens <n>      Maximum tokens to generate
-  -c, --config <path>          Path to config file
+  -c, --config <path>          Path to config directory
   --providers                  List supported providers and their API key status
   --completions <shell>        Generate shell completions (bash, zsh, fish)
   -V, --version                Print version

--- a/package.json
+++ b/package.json
@@ -26,12 +26,23 @@
   },
   "keywords": [
     "ai",
+    "cli",
+    "llm",
+    "openai",
+    "anthropic",
+    "pipe",
+    "terminal",
     "openrouter",
     "vercel-ai-sdk"
   ],
+  "author": "Andrew Bierman",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/andrew-bierman/ai-cli.git"
+    "url": "git+https://github.com/andrew-bierman/ai-pipe.git"
+  },
+  "homepage": "https://github.com/andrew-bierman/ai-pipe#readme",
+  "bugs": {
+    "url": "https://github.com/andrew-bierman/ai-pipe/issues"
   },
   "license": "MIT",
   "dependencies": {

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -2,9 +2,16 @@ import { test, expect, describe } from "bun:test";
 import { loadConfig, ConfigSchema } from "../config.ts";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { mkdirSync } from "node:fs";
 
 const tmpDir = tmpdir();
 const uid = () => `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+
+function makeTmpDir(): string {
+  const dir = join(tmpDir, `ai-cfg-${uid()}`);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
 
 describe("ConfigSchema", () => {
   test("accepts empty object", () => {
@@ -81,19 +88,149 @@ describe("ConfigSchema", () => {
     expect((result as Record<string, unknown>).unknown).toBeUndefined();
   });
 
-  test("accepts apiKeys with valid provider names", () => {
+  test("does not accept apiKeys (moved to separate file)", () => {
     const result = ConfigSchema.parse({
-      apiKeys: { anthropic: "sk-ant-test", openai: "sk-test" },
+      model: "openai/gpt-4o",
+      apiKeys: { openai: "sk-test" },
     });
-    expect(result.apiKeys).toEqual({ anthropic: "sk-ant-test", openai: "sk-test" });
+    expect((result as Record<string, unknown>).apiKeys).toBeUndefined();
+  });
+});
+
+describe("loadConfig", () => {
+  test("returns empty object when directory does not exist", async () => {
+    const config = await loadConfig("/nonexistent/path/config-dir");
+    expect(config).toEqual({});
   });
 
-  test("accepts empty apiKeys object", () => {
-    const result = ConfigSchema.parse({ apiKeys: {} });
-    expect(result.apiKeys).toEqual({});
+  test("returns empty object for empty directory", async () => {
+    const dir = makeTmpDir();
+    const config = await loadConfig(dir);
+    expect(config).toEqual({});
   });
 
-  test("accepts apiKeys with all providers", () => {
+  test("loads config.json only", async () => {
+    const dir = makeTmpDir();
+    await Bun.write(
+      join(dir, "config.json"),
+      JSON.stringify({
+        model: "anthropic/claude-sonnet-4-5",
+        system: "Be concise.",
+        temperature: 0.7,
+        maxOutputTokens: 500,
+      })
+    );
+
+    const config = await loadConfig(dir);
+    expect(config.model).toBe("anthropic/claude-sonnet-4-5");
+    expect(config.system).toBe("Be concise.");
+    expect(config.temperature).toBe(0.7);
+    expect(config.maxOutputTokens).toBe(500);
+    expect(config.apiKeys).toBeUndefined();
+  });
+
+  test("loads apiKeys.json only", async () => {
+    const dir = makeTmpDir();
+    await Bun.write(
+      join(dir, "apiKeys.json"),
+      JSON.stringify({ anthropic: "sk-ant-test", openai: "sk-test" })
+    );
+
+    const config = await loadConfig(dir);
+    expect(config.model).toBeUndefined();
+    expect(config.apiKeys).toEqual({ anthropic: "sk-ant-test", openai: "sk-test" });
+  });
+
+  test("loads both config.json and apiKeys.json", async () => {
+    const dir = makeTmpDir();
+    await Promise.all([
+      Bun.write(
+        join(dir, "config.json"),
+        JSON.stringify({ model: "anthropic/claude-sonnet-4-5" })
+      ),
+      Bun.write(
+        join(dir, "apiKeys.json"),
+        JSON.stringify({ anthropic: "sk-ant-test" })
+      ),
+    ]);
+
+    const config = await loadConfig(dir);
+    expect(config.model).toBe("anthropic/claude-sonnet-4-5");
+    expect(config.apiKeys).toEqual({ anthropic: "sk-ant-test" });
+  });
+
+  test("loads partial config.json (only model)", async () => {
+    const dir = makeTmpDir();
+    await Bun.write(join(dir, "config.json"), JSON.stringify({ model: "google/gemini-2.5-flash" }));
+
+    const config = await loadConfig(dir);
+    expect(config.model).toBe("google/gemini-2.5-flash");
+    expect(config.system).toBeUndefined();
+    expect(config.temperature).toBeUndefined();
+    expect(config.maxOutputTokens).toBeUndefined();
+  });
+
+  test("loads empty JSON object config.json", async () => {
+    const dir = makeTmpDir();
+    await Bun.write(join(dir, "config.json"), "{}");
+
+    const config = await loadConfig(dir);
+    expect(config).toEqual({});
+  });
+
+  test("ignores invalid JSON in config.json", async () => {
+    const dir = makeTmpDir();
+    await Bun.write(join(dir, "config.json"), "not valid json {{{");
+
+    const config = await loadConfig(dir);
+    expect(config).toEqual({});
+  });
+
+  test("ignores invalid JSON in apiKeys.json", async () => {
+    const dir = makeTmpDir();
+    await Bun.write(join(dir, "apiKeys.json"), "not valid json");
+
+    const config = await loadConfig(dir);
+    expect(config).toEqual({});
+  });
+
+  test("ignores zod-invalid config.json (temperature out of range)", async () => {
+    const dir = makeTmpDir();
+    await Bun.write(join(dir, "config.json"), JSON.stringify({ temperature: 5 }));
+
+    const config = await loadConfig(dir);
+    expect(config).toEqual({});
+  });
+
+  test("ignores zod-invalid config.json (bad type)", async () => {
+    const dir = makeTmpDir();
+    await Bun.write(join(dir, "config.json"), JSON.stringify({ model: 42 }));
+
+    const config = await loadConfig(dir);
+    expect(config).toEqual({});
+  });
+
+  test("ignores array JSON in config.json", async () => {
+    const dir = makeTmpDir();
+    await Bun.write(join(dir, "config.json"), "[1, 2, 3]");
+
+    const config = await loadConfig(dir);
+    expect(config).toEqual({});
+  });
+
+  test("ignores apiKeys.json with unknown provider", async () => {
+    const dir = makeTmpDir();
+    await Bun.write(
+      join(dir, "apiKeys.json"),
+      JSON.stringify({ fakeprovider: "sk-test" })
+    );
+
+    const config = await loadConfig(dir);
+    expect(config).toEqual({});
+  });
+
+  test("valid apiKeys.json with all providers", async () => {
+    const dir = makeTmpDir();
     const keys = {
       openai: "sk-1",
       anthropic: "sk-2",
@@ -106,131 +243,37 @@ describe("ConfigSchema", () => {
       cohere: "sk-9",
       openrouter: "sk-10",
     };
-    const result = ConfigSchema.parse({ apiKeys: keys });
-    expect(result.apiKeys).toEqual(keys);
+    await Bun.write(join(dir, "apiKeys.json"), JSON.stringify(keys));
+
+    const config = await loadConfig(dir);
+    expect(config.apiKeys).toEqual(keys);
   });
 
-  test("rejects apiKeys with unknown provider", () => {
-    expect(() =>
-      ConfigSchema.parse({ apiKeys: { fakeprovider: "sk-test" } })
-    ).toThrow();
+  test("invalid config.json does not affect valid apiKeys.json", async () => {
+    const dir = makeTmpDir();
+    await Promise.all([
+      Bun.write(join(dir, "config.json"), "bad json"),
+      Bun.write(join(dir, "apiKeys.json"), JSON.stringify({ openai: "sk-test" })),
+    ]);
+
+    const config = await loadConfig(dir);
+    expect(config.model).toBeUndefined();
+    expect(config.apiKeys).toEqual({ openai: "sk-test" });
   });
 
-  test("rejects apiKeys with non-string value", () => {
-    expect(() =>
-      ConfigSchema.parse({ apiKeys: { openai: 123 } })
-    ).toThrow();
+  test("invalid apiKeys.json does not affect valid config.json", async () => {
+    const dir = makeTmpDir();
+    await Promise.all([
+      Bun.write(join(dir, "config.json"), JSON.stringify({ model: "openai/gpt-4o" })),
+      Bun.write(join(dir, "apiKeys.json"), "bad json"),
+    ]);
+
+    const config = await loadConfig(dir);
+    expect(config.model).toBe("openai/gpt-4o");
+    expect(config.apiKeys).toBeUndefined();
   });
 
-  test("config without apiKeys has undefined apiKeys", () => {
-    const result = ConfigSchema.parse({ model: "openai/gpt-4o" });
-    expect(result.apiKeys).toBeUndefined();
-  });
-});
-
-describe("loadConfig", () => {
-  test("returns empty object when file does not exist", async () => {
-    const config = await loadConfig("/nonexistent/path/config.json");
-    expect(config).toEqual({});
-  });
-
-  test("loads valid full config file", async () => {
-    const path = join(tmpDir, `ai-cfg-${uid()}.json`);
-    await Bun.write(
-      path,
-      JSON.stringify({
-        model: "anthropic/claude-sonnet-4-5",
-        system: "Be concise.",
-        temperature: 0.7,
-        maxOutputTokens: 500,
-      })
-    );
-
-    const config = await loadConfig(path);
-    expect(config.model).toBe("anthropic/claude-sonnet-4-5");
-    expect(config.system).toBe("Be concise.");
-    expect(config.temperature).toBe(0.7);
-    expect(config.maxOutputTokens).toBe(500);
-  });
-
-  test("loads partial config (only model)", async () => {
-    const path = join(tmpDir, `ai-cfg-${uid()}.json`);
-    await Bun.write(path, JSON.stringify({ model: "google/gemini-2.5-flash" }));
-
-    const config = await loadConfig(path);
-    expect(config.model).toBe("google/gemini-2.5-flash");
-    expect(config.system).toBeUndefined();
-    expect(config.temperature).toBeUndefined();
-    expect(config.maxOutputTokens).toBeUndefined();
-  });
-
-  test("loads empty JSON object config", async () => {
-    const path = join(tmpDir, `ai-cfg-${uid()}.json`);
-    await Bun.write(path, "{}");
-
-    const config = await loadConfig(path);
-    expect(config).toEqual({});
-  });
-
-  test("returns empty object for invalid JSON syntax", async () => {
-    const path = join(tmpDir, `ai-cfg-${uid()}.json`);
-    await Bun.write(path, "not valid json {{{");
-
-    const config = await loadConfig(path);
-    expect(config).toEqual({});
-  });
-
-  test("returns empty object for zod-invalid config (temperature out of range)", async () => {
-    const path = join(tmpDir, `ai-cfg-${uid()}.json`);
-    await Bun.write(path, JSON.stringify({ temperature: 5 }));
-
-    const config = await loadConfig(path);
-    expect(config).toEqual({});
-  });
-
-  test("returns empty object for zod-invalid config (bad type)", async () => {
-    const path = join(tmpDir, `ai-cfg-${uid()}.json`);
-    await Bun.write(path, JSON.stringify({ model: 42 }));
-
-    const config = await loadConfig(path);
-    expect(config).toEqual({});
-  });
-
-  test("returns empty object for array JSON", async () => {
-    const path = join(tmpDir, `ai-cfg-${uid()}.json`);
-    await Bun.write(path, "[1, 2, 3]");
-
-    const config = await loadConfig(path);
-    expect(config).toEqual({});
-  });
-
-  test("loads config with apiKeys", async () => {
-    const path = join(tmpDir, `ai-cfg-${uid()}.json`);
-    await Bun.write(
-      path,
-      JSON.stringify({
-        model: "anthropic/claude-sonnet-4-5",
-        apiKeys: { anthropic: "sk-ant-test", openai: "sk-test" },
-      })
-    );
-
-    const config = await loadConfig(path);
-    expect(config.model).toBe("anthropic/claude-sonnet-4-5");
-    expect(config.apiKeys).toEqual({ anthropic: "sk-ant-test", openai: "sk-test" });
-  });
-
-  test("returns empty object for config with invalid apiKeys provider", async () => {
-    const path = join(tmpDir, `ai-cfg-${uid()}.json`);
-    await Bun.write(
-      path,
-      JSON.stringify({ apiKeys: { fakeprovider: "sk-test" } })
-    );
-
-    const config = await loadConfig(path);
-    expect(config).toEqual({});
-  });
-
-  test("uses default path when none specified", async () => {
+  test("uses default directory when none specified", async () => {
     const config = await loadConfig(undefined);
     expect(config).toBeDefined();
   });

--- a/src/__tests__/constants.test.ts
+++ b/src/__tests__/constants.test.ts
@@ -24,8 +24,10 @@ describe("APP", () => {
     expect(APP.temperature.max).toBe(2);
   });
 
-  test("has config file name", () => {
-    expect(APP.configFileName).toBe(".ai-pipe.json");
+  test("has config directory and file names", () => {
+    expect(APP.configDirName).toBe(".ai-pipe");
+    expect(APP.configFile).toBe("config.json");
+    expect(APP.apiKeysFile).toBe("apiKeys.json");
   });
 
   test("has supported shells", () => {

--- a/src/completions.ts
+++ b/src/completions.ts
@@ -46,7 +46,7 @@ _${funcName}_completions() {
       return 0
       ;;
     -c|--config)
-      COMPREPLY=( $(compgen -f -- "\${cur}") )
+      COMPREPLY=( $(compgen -d -- "\${cur}") )
       return 0
       ;;
     --completions)
@@ -80,7 +80,7 @@ _${funcName}() {
     '--no-stream[Wait for full response, then print]' \\
     '(-t --temperature)'{-t,--temperature}'[Sampling temperature (${APP.temperature.min}-${APP.temperature.max})]:temp:' \\
     '--max-output-tokens[Maximum tokens to generate]:tokens:' \\
-    '(-c --config)'{-c,--config}'[Path to config file]:file:_files' \\
+    '(-c --config)'{-c,--config}'[Path to config directory]:dir:_directories' \\
     '--providers[List supported providers]' \\
     '--completions[Generate shell completions]:shell:(${shells})' \\
     '(-V --version)'{-V,--version}'[Print version]' \\
@@ -106,7 +106,7 @@ complete -c ${name} -s j -l json -d 'Output full JSON response object'
 complete -c ${name} -l no-stream -d 'Wait for full response, then print'
 complete -c ${name} -s t -l temperature -d 'Sampling temperature (${APP.temperature.min}-${APP.temperature.max})' -x
 complete -c ${name} -l max-output-tokens -d 'Maximum tokens to generate' -x
-complete -c ${name} -s c -l config -d 'Path to config file' -r -F
+complete -c ${name} -s c -l config -d 'Path to config directory' -x -a '(__fish_complete_directories)'
 complete -c ${name} -l providers -d 'List supported providers'
 complete -c ${name} -l completions -d 'Generate shell completions' -x -a '${shells}'
 complete -c ${name} -s V -l version -d 'Print version'

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -12,7 +12,9 @@ export const AppSchema = z.object({
     min: z.number(),
     max: z.number(),
   }),
-  configFileName: z.string(),
+  configDirName: z.string(),
+  configFile: z.string(),
+  apiKeysFile: z.string(),
   supportedShells: z.array(ShellSchema),
 });
 
@@ -24,6 +26,8 @@ export const APP: AppConfig = AppSchema.parse({
   defaultModel: "openai/gpt-4o",
   defaultProvider: "openai",
   temperature: { min: 0, max: 2 },
-  configFileName: ".ai-pipe.json",
+  configDirName: ".ai-pipe",
+  configFile: "config.json",
+  apiKeysFile: "apiKeys.json",
   supportedShells: ["bash", "zsh", "fish"],
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -201,7 +201,7 @@ if (import.meta.main) {
     .option("--no-stream", "Wait for full response, then print")
     .option("-t, --temperature <n>", `Sampling temperature (${APP.temperature.min}-${APP.temperature.max})`, parseFloat)
     .option("--max-output-tokens <n>", "Maximum tokens to generate", parseInt)
-    .option("-c, --config <path>", "Path to config file")
+    .option("-c, --config <path>", "Path to config directory")
     .option("--providers", "List supported providers and their API key status")
     .option("--completions <shell>", `Generate shell completions (${APP.supportedShells.join(", ")})`)
     .action(run);


### PR DESCRIPTION
## Summary
- Migrate from single `~/.ai-pipe.json` to `~/.ai-pipe/` directory with separate `config.json` and `apiKeys.json`
- Separates secrets (API keys) from settings for better security hygiene
- Prep `package.json` for npm publishing (author, homepage, bugs, repo URL, keywords)
- Update shell completions to complete directories instead of files for `-c` flag

## Test plan
- [x] `bun test` — 197 tests pass
- [ ] Manual: verify `~/.ai-pipe/config.json` loads settings
- [ ] Manual: verify `~/.ai-pipe/apiKeys.json` provides API keys
- [ ] Manual: verify `-c /custom/dir` works with directory path