### PR TITLE
♻️ Extract hardcoded strings into APP constants object

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,13 @@ Built on the [Vercel AI SDK](https://sdk.vercel.ai/) with [Bun](https://bun.sh/)
 ## Install
 
 ```sh
-git clone https://github.com/andrew-bierman/ai-cli.git
-cd ai-cli
+git clone https://github.com/andrew-bierman/ai-pipe.git
+cd ai-pipe
 bun install
 bun link
 ```
+
+This installs both `ai-pipe` and `ai` as CLI commands.
 
 ## Setup
 
@@ -35,6 +37,8 @@ export AZURE_AI_API_KEY="..."
 export TOGETHERAI_API_KEY="..."
 export AWS_ACCESS_KEY_ID="..."
 export AWS_SECRET_ACCESS_KEY="..."
+export GOOGLE_VERTEX_PROJECT="my-project"
+export GOOGLE_VERTEX_LOCATION="us-central1"
 export HF_TOKEN="hf_..."
 
 # Ollama (local)
@@ -92,7 +96,7 @@ If no `provider/` prefix is given, the model defaults to `openai`. If no `-m` fl
 | azure | `AZURE_AI_API_KEY` | `azure/azure-model-id` |
 | togetherai | `TOGETHERAI_API_KEY` | `togetherai/meta-llama/Llama-3.3-70b-Instruct` |
 | bedrock | `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` | `bedrock/anthropic.claude-sonnet-4-2025-02-19` |
-| vertex | `GOOGLE_VERTEX_PROJECT` | `vertex/google/cloud/llama-3.1` |
+| vertex | `GOOGLE_VERTEX_PROJECT`, `GOOGLE_VERTEX_LOCATION` | `vertex/google/cloud/llama-3.1` |
 | ollama | `OLLAMA_HOST` | `ollama/llama3` |
 | huggingface | `HF_TOKEN` | `huggingface/meta-llama/Llama-3.3-70b-Instruct` |
 
@@ -200,7 +204,7 @@ Binaries are output to `dist/`.
 
 ```sh
 bun install
-bun test              # 172 tests across 6 files
+bun test              # 210 tests across 7 files
 bun run typecheck     # TypeScript type checking
 ```
 

--- a/src/__tests__/constants.test.ts
+++ b/src/__tests__/constants.test.ts
@@ -1,0 +1,65 @@
+import { test, expect, describe } from "bun:test";
+import { APP, AppSchema, ShellSchema, type Shell, type AppConfig } from "../constants.ts";
+
+describe("APP", () => {
+  test("validates against AppSchema", () => {
+    expect(AppSchema.parse(APP)).toEqual(APP);
+  });
+
+  test("has expected name", () => {
+    expect(APP.name).toBe("ai-pipe");
+  });
+
+  test("has expected default model", () => {
+    expect(APP.defaultModel).toBe("openai/gpt-4o");
+  });
+
+  test("has expected default provider", () => {
+    expect(APP.defaultProvider).toBe("openai");
+  });
+
+  test("temperature has valid range", () => {
+    expect(APP.temperature.min).toBeLessThan(APP.temperature.max);
+    expect(APP.temperature.min).toBe(0);
+    expect(APP.temperature.max).toBe(2);
+  });
+
+  test("has config file name", () => {
+    expect(APP.configFileName).toBe(".ai-pipe.json");
+  });
+
+  test("has supported shells", () => {
+    expect(APP.supportedShells).toContain("bash");
+    expect(APP.supportedShells).toContain("zsh");
+    expect(APP.supportedShells).toContain("fish");
+    expect(APP.supportedShells).toHaveLength(3);
+  });
+});
+
+describe("ShellSchema", () => {
+  for (const shell of APP.supportedShells) {
+    test(`accepts "${shell}"`, () => {
+      expect(ShellSchema.parse(shell)).toBe(shell);
+    });
+  }
+
+  test("rejects unknown shell", () => {
+    expect(ShellSchema.safeParse("powershell").success).toBe(false);
+  });
+
+  test("rejects empty string", () => {
+    expect(ShellSchema.safeParse("").success).toBe(false);
+  });
+});
+
+describe("AppSchema", () => {
+  test("rejects invalid config", () => {
+    const result = AppSchema.safeParse({ name: 123 });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects missing fields", () => {
+    const result = AppSchema.safeParse({});
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { ProviderIdSchema, SUPPORTED_PROVIDERS } from "./provider.ts";
+import { APP } from "./constants.ts";
 
 const ApiKeysSchema = z.record(z.string(), z.string()).refine(
   (obj) => Object.keys(obj).every((k) => ProviderIdSchema.safeParse(k).success),
@@ -11,14 +12,14 @@ const ApiKeysSchema = z.record(z.string(), z.string()).refine(
 export const ConfigSchema = z.object({
   model: z.string().optional(),
   system: z.string().optional(),
-  temperature: z.number().min(0).max(2).optional(),
+  temperature: z.number().min(APP.temperature.min).max(APP.temperature.max).optional(),
   maxOutputTokens: z.number().int().positive().optional(),
   apiKeys: ApiKeysSchema.optional(),
 });
 
 export type Config = z.infer<typeof ConfigSchema>;
 
-const DEFAULT_CONFIG_PATH = join(homedir(), ".ai-pipe.json");
+const DEFAULT_CONFIG_PATH = join(homedir(), APP.configFileName);
 
 export async function loadConfig(configPath?: string): Promise<Config> {
   const path = configPath ?? DEFAULT_CONFIG_PATH;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,29 @@
+import { z } from "zod";
+
+export const ShellSchema = z.enum(["bash", "zsh", "fish"]);
+export type Shell = z.infer<typeof ShellSchema>;
+
+export const AppSchema = z.object({
+  name: z.string(),
+  description: z.string(),
+  defaultModel: z.string(),
+  defaultProvider: z.string(),
+  temperature: z.object({
+    min: z.number(),
+    max: z.number(),
+  }),
+  configFileName: z.string(),
+  supportedShells: z.array(ShellSchema),
+});
+
+export type AppConfig = z.infer<typeof AppSchema>;
+
+export const APP: AppConfig = AppSchema.parse({
+  name: "ai-pipe",
+  description: "A lean CLI for calling LLMs from the terminal.",
+  defaultModel: "openai/gpt-4o",
+  defaultProvider: "openai",
+  temperature: { min: 0, max: 2 },
+  configFileName: ".ai-pipe.json",
+  supportedShells: ["bash", "zsh", "fish"],
+});

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { createProviderRegistry } from "ai";
 import type { ProviderV3 } from "@ai-sdk/provider";
+import { APP } from "./constants.ts";
 import { openai } from "@ai-sdk/openai";
 import { anthropic } from "@ai-sdk/anthropic";
 import { google } from "@ai-sdk/google";
@@ -67,15 +68,13 @@ export const PROVIDER_ENV_VARS: Record<ProviderId, string[]> = {
   huggingface: ["HF_TOKEN"],
 };
 
-const DEFAULT_PROVIDER: ProviderId = "openai";
-
 export const ModelStringSchema = z
   .string()
   .min(1, "Model string cannot be empty")
   .transform((val) => {
     const slashIndex = val.indexOf("/");
     if (slashIndex === -1) {
-      return { provider: DEFAULT_PROVIDER, modelId: val, fullId: `${DEFAULT_PROVIDER}/${val}` };
+      return { provider: APP.defaultProvider, modelId: val, fullId: `${APP.defaultProvider}/${val}` };
     }
     return {
       provider: val.slice(0, slashIndex),


### PR DESCRIPTION
## Summary
- Adds `src/constants.ts` with a Zod-validated `APP` config object that centralizes hardcoded strings (app name, default model, temperature range, config file name, supported shells)
- Replaces scattered string literals across `index.ts`, `config.ts`, `provider.ts`, and `completions.ts` with `APP.x` references
- Uses `ShellSchema` enum for type-safe shell validation in completions
- Replaces `as ProviderId` type assertion with proper `ProviderIdSchema.safeParse()` validation
- Fixes apiKeys injection bug where `PROVIDER_ENV_VARS[provider]` (now `string[]`) was treated as `string`
- Updates README: fixes repo URL, adds missing vertex env vars, updates test count

## Test plan
- [x] All 210 tests pass across 7 files
- [x] TypeScript typecheck clean
- [x] New `constants.test.ts` covers APP object, ShellSchema, and AppSchema validation
- [ ] Manual: `ai-pipe --help` shows correct app name and descriptions
- [ ] Manual: `ai-pipe --completions bash` generates correct function names
- [ ] Manual: `ai-pipe --providers` works as expected