### PR TITLE
🚀 Add release workflow for npm + GitHub releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,100 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - run: bun install --frozen-lockfile
+
+      - name: Typecheck
+        run: bun run typecheck
+
+      - name: Test
+        run: bun test
+
+  publish:
+    name: Publish to npm
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - run: bun install --frozen-lockfile
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  github-release:
+    name: GitHub Release
+    needs: [test, publish]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - target: bun-linux-x64
+            outfile: ai-pipe-linux-x64
+          - target: bun-linux-arm64
+            outfile: ai-pipe-linux-arm64
+          - target: bun-darwin-arm64
+            outfile: ai-pipe-darwin-arm64
+          - target: bun-darwin-x64
+            outfile: ai-pipe-darwin-x64
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - run: bun install --frozen-lockfile
+
+      - name: Compile ${{ matrix.outfile }}
+        run: bun build src/index.ts --compile --target=${{ matrix.target }} --outfile dist/${{ matrix.outfile }}
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.outfile }}
+          path: dist/${{ matrix.outfile }}
+
+  create-release:
+    name: Create GitHub Release
+    needs: github-release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: Create release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: dist/*


### PR DESCRIPTION
## Summary
- Add `.github/workflows/release.yml` that triggers on version tags (`v*`)
- Pipeline: test → publish to npm → build cross-platform binaries → create GitHub release with binaries attached
- Auto-generates release notes from commit history

## Release workflow
```sh
# Bump version (patch/minor/major), creates git tag
npm version patch

# Push commit + tag to trigger the release
git push --follow-tags
```

## Setup required
1. Create an npm access token (Granular Access Token recommended)
2. Add it as `NPM_TOKEN` in GitHub repo Settings → Secrets → Actions

## Test plan
- [x] Workflow YAML is valid
- [ ] Manual: verify `NPM_TOKEN` secret is set before first release