### PR TITLE
🔧 Add Biome linter/formatter and Lefthook pre-commit hook

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.3.14/schema.json",
+  "assist": {
+    "enabled": true
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "nursery": {
+        "useMaxParams": {
+          "level": "warn",
+          "options": {
+            "max": 3
+          }
+        }
+      }
+    }
+  }
+}

--- a/bun.lock
+++ b/bun.lock
@@ -27,7 +27,9 @@
         "zod": "^4.3.6",
       },
       "devDependencies": {
+        "@biomejs/biome": "^2.3.14",
         "@types/bun": "latest",
+        "lefthook": "^2.1.0",
       },
       "peerDependencies": {
         "typescript": "^5",
@@ -76,6 +78,24 @@
     "@aws-crypto/util": ["@aws-crypto/util@5.2.0", "", { "dependencies": { "@aws-sdk/types": "^3.222.0", "@smithy/util-utf8": "^2.0.0", "tslib": "^2.6.2" } }, "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ=="],
 
     "@aws-sdk/types": ["@aws-sdk/types@3.973.1", "", { "dependencies": { "@smithy/types": "^4.12.0", "tslib": "^2.6.2" } }, "sha512-DwHBiMNOB468JiX6+i34c+THsKHErYUdNQ3HexeXZvVn4zouLjgaS4FejiGSi2HyBuzuyHg7SuOPmjSvoU9NRg=="],
+
+    "@biomejs/biome": ["@biomejs/biome@2.3.14", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.3.14", "@biomejs/cli-darwin-x64": "2.3.14", "@biomejs/cli-linux-arm64": "2.3.14", "@biomejs/cli-linux-arm64-musl": "2.3.14", "@biomejs/cli-linux-x64": "2.3.14", "@biomejs/cli-linux-x64-musl": "2.3.14", "@biomejs/cli-win32-arm64": "2.3.14", "@biomejs/cli-win32-x64": "2.3.14" }, "bin": { "biome": "bin/biome" } }, "sha512-QMT6QviX0WqXJCaiqVMiBUCr5WRQ1iFSjvOLoTk6auKukJMvnMzWucXpwZB0e8F00/1/BsS9DzcKgWH+CLqVuA=="],
+
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.3.14", "", { "os": "darwin", "cpu": "arm64" }, "sha512-UJGPpvWJMkLxSRtpCAKfKh41Q4JJXisvxZL8ChN1eNW3m/WlPFJ6EFDCE7YfUb4XS8ZFi3C1dFpxUJ0Ety5n+A=="],
+
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.3.14", "", { "os": "darwin", "cpu": "x64" }, "sha512-PNkLNQG6RLo8lG7QoWe/hhnMxJIt1tEimoXpGQjwS/dkdNiKBLPv4RpeQl8o3s1OKI3ZOR5XPiYtmbGGHAOnLA=="],
+
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.3.14", "", { "os": "linux", "cpu": "arm64" }, "sha512-KT67FKfzIw6DNnUNdYlBg+eU24Go3n75GWK6NwU4+yJmDYFe9i/MjiI+U/iEzKvo0g7G7MZqoyrhIYuND2w8QQ=="],
+
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.3.14", "", { "os": "linux", "cpu": "arm64" }, "sha512-LInRbXhYujtL3sH2TMCH/UBwJZsoGwfQjBrMfl84CD4hL/41C/EU5mldqf1yoFpsI0iPWuU83U+nB2TUUypWeg=="],
+
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.3.14", "", { "os": "linux", "cpu": "x64" }, "sha512-ZsZzQsl9U+wxFrGGS4f6UxREUlgHwmEfu1IrXlgNFrNnd5Th6lIJr8KmSzu/+meSa9f4rzFrbEW9LBBA6ScoMA=="],
+
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.3.14", "", { "os": "linux", "cpu": "x64" }, "sha512-KQU7EkbBBuHPW3/rAcoiVmhlPtDSGOGRPv9js7qJVpYTzjQmVR+C9Rfcz+ti8YCH+zT1J52tuBybtP4IodjxZQ=="],
+
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.3.14", "", { "os": "win32", "cpu": "arm64" }, "sha512-+IKYkj/pUBbnRf1G1+RlyA3LWiDgra1xpS7H2g4BuOzzRbRB+hmlw0yFsLprHhbbt7jUzbzAbAjK/Pn0FDnh1A=="],
+
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.3.14", "", { "os": "win32", "cpu": "x64" }, "sha512-oizCjdyQ3WJEswpb3Chdngeat56rIdSYK12JI3iI11Mt5T5EXcZ7WLuowzEaFPNJ3zmOQFliMN8QY1Pi+qsfdQ=="],
 
     "@isaacs/cliui": ["@isaacs/cliui@8.0.2", "", { "dependencies": { "string-width": "^5.1.2", "string-width-cjs": "npm:string-width@^4.2.0", "strip-ansi": "^7.0.1", "strip-ansi-cjs": "npm:strip-ansi@^6.0.1", "wrap-ansi": "^8.1.0", "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0" } }, "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA=="],
 
@@ -184,6 +204,28 @@
     "jwa": ["jwa@2.0.1", "", { "dependencies": { "buffer-equal-constant-time": "^1.0.1", "ecdsa-sig-formatter": "1.0.11", "safe-buffer": "^5.0.1" } }, "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg=="],
 
     "jws": ["jws@4.0.1", "", { "dependencies": { "jwa": "^2.0.1", "safe-buffer": "^5.0.1" } }, "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA=="],
+
+    "lefthook": ["lefthook@2.1.0", "", { "optionalDependencies": { "lefthook-darwin-arm64": "2.1.0", "lefthook-darwin-x64": "2.1.0", "lefthook-freebsd-arm64": "2.1.0", "lefthook-freebsd-x64": "2.1.0", "lefthook-linux-arm64": "2.1.0", "lefthook-linux-x64": "2.1.0", "lefthook-openbsd-arm64": "2.1.0", "lefthook-openbsd-x64": "2.1.0", "lefthook-windows-arm64": "2.1.0", "lefthook-windows-x64": "2.1.0" }, "bin": { "lefthook": "bin/index.js" } }, "sha512-+vS+yywGQW6CN1J1hbGkez//6ixGHIQqfxDN/d3JDm531w9GfGt2lAWTDfZTw/CEl80XsN0raFcnEraR3ldw9g=="],
+
+    "lefthook-darwin-arm64": ["lefthook-darwin-arm64@2.1.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-u2hjHLQXWSFfzO7ln2n/uEydSzfC9sc5cDC7tvKSuOdhvBwaJ0AQ7ZeuqqCQ4YfVIJfYOom1SVE9CBd10FVyig=="],
+
+    "lefthook-darwin-x64": ["lefthook-darwin-x64@2.1.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-zz5rcyrtOZpxon7uE+c0KC/o2ypJeLZql5CL0Y9oaTuECbmhfokm8glsGnyWstW/++PuMpZYYr/qsCJA5elxkQ=="],
+
+    "lefthook-freebsd-arm64": ["lefthook-freebsd-arm64@2.1.0", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-+mXNCNuFHNGYLrDqYWDeHH7kWCLCJFPpspx5PAAm+PD37PRMZJrTqDbaNK9qCghC1tdmT4/Lvilf/ewXHPlaKw=="],
+
+    "lefthook-freebsd-x64": ["lefthook-freebsd-x64@2.1.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-+AU2HD7szuDsUdHue/E3OnF84B2ae/h7CGKpuIUHJntgoJ4kxf89oDvq2/xl8kDCn9cT76UUjgeZUgFYLRj+6Q=="],
+
+    "lefthook-linux-arm64": ["lefthook-linux-arm64@2.1.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-KM70eV1tsEib1/tk+3TFxIdH84EaYlIg5KTQWAg+LB1N23nTQ7lL4Dnh1je6f6KW4tf21nmoMUqsh0xvMkQk8Q=="],
+
+    "lefthook-linux-x64": ["lefthook-linux-x64@2.1.0", "", { "os": "linux", "cpu": "x64" }, "sha512-6Bxmv+l7LiYq9W0IE6v2lmlRtBp6pisnlzhcouMGvH3rDwEGw11NAyRJZA3IPGEMAkIuhnlnVTUwAUzKomfJLg=="],
+
+    "lefthook-openbsd-arm64": ["lefthook-openbsd-arm64@2.1.0", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-ppJNK0bBSPLC8gqksRw5zI/0uLeMA5cK+hmZ4ofcuGNmdrN1dfl2Tx84fdeef0NcQY0ii9Y3j3icIKngIoid/g=="],
+
+    "lefthook-openbsd-x64": ["lefthook-openbsd-x64@2.1.0", "", { "os": "openbsd", "cpu": "x64" }, "sha512-8k9lQsMYqQGu4spaQ8RNSOJidxIcOyfaoF2FPZhthtBfRV3cgVFGrsQ0hbIi5pvQRGUlCqYuCN79qauXHmnL3Q=="],
+
+    "lefthook-windows-arm64": ["lefthook-windows-arm64@2.1.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-0WN+grrxt9zP9NGRcztoPXcz25tteem91rfLWgQFab+50csJ47zldlsB7/eOS/eHG5mUg5g5NPR4XefnXtjOcQ=="],
+
+    "lefthook-windows-x64": ["lefthook-windows-x64@2.1.0", "", { "os": "win32", "cpu": "x64" }, "sha512-XbO/5nAZQLpUn0tPpgCYfFBFJHnymSglQ73jD6wymNrR1j8I5EcXGlP6YcLhnZ83yzsdLC+gup+N6IqUeiyRdw=="],
 
     "lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,7 @@
+pre-commit:
+  parallel: true
+  jobs:
+    - name: lint
+      run: bunx biome check --write {staged_files}
+      glob: "*.{ts,tsx,js,jsx,json,css}"
+      stage_fixed: true

--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
     "build:mac": "bun build src/index.ts --compile --target=bun-darwin-arm64 --outfile dist/ai-pipe-darwin-arm64",
     "build:mac-x64": "bun build src/index.ts --compile --target=bun-darwin-x64 --outfile dist/ai-pipe-darwin-x64",
     "build:all": "bun run build:mac && bun run build:mac-x64 && bun run build:linux && bun run build:linux-arm",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "lint": "bunx biome check --write .",
+    "lint:check": "bunx biome check ."
   },
   "keywords": [
     "ai",
@@ -68,7 +70,9 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
-    "@types/bun": "latest"
+    "@biomejs/biome": "^2.3.14",
+    "@types/bun": "latest",
+    "lefthook": "^2.1.0"
   },
   "peerDependencies": {
     "typescript": "^5"

--- a/src/__tests__/completions.test.ts
+++ b/src/__tests__/completions.test.ts
@@ -1,4 +1,4 @@
-import { test, expect, describe } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { generateCompletions } from "../completions.ts";
 import { SUPPORTED_PROVIDERS } from "../provider.ts";
 

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -1,8 +1,8 @@
-import { test, expect, describe } from "bun:test";
-import { loadConfig, ConfigSchema } from "../config.ts";
-import { join } from "node:path";
-import { tmpdir } from "node:os";
+import { describe, expect, test } from "bun:test";
 import { mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { ConfigSchema, loadConfig } from "../config.ts";
 
 const tmpDir = tmpdir();
 const uid = () => `${Date.now()}-${Math.random().toString(36).slice(2)}`;
@@ -84,7 +84,10 @@ describe("ConfigSchema", () => {
   });
 
   test("strips unknown properties", () => {
-    const result = ConfigSchema.parse({ model: "openai/gpt-4o", unknown: true });
+    const result = ConfigSchema.parse({
+      model: "openai/gpt-4o",
+      unknown: true,
+    });
     expect((result as Record<string, unknown>).unknown).toBeUndefined();
   });
 
@@ -118,7 +121,7 @@ describe("loadConfig", () => {
         system: "Be concise.",
         temperature: 0.7,
         maxOutputTokens: 500,
-      })
+      }),
     );
 
     const config = await loadConfig(dir);
@@ -133,12 +136,15 @@ describe("loadConfig", () => {
     const dir = makeTmpDir();
     await Bun.write(
       join(dir, "apiKeys.json"),
-      JSON.stringify({ anthropic: "sk-ant-test", openai: "sk-test" })
+      JSON.stringify({ anthropic: "sk-ant-test", openai: "sk-test" }),
     );
 
     const config = await loadConfig(dir);
     expect(config.model).toBeUndefined();
-    expect(config.apiKeys).toEqual({ anthropic: "sk-ant-test", openai: "sk-test" });
+    expect(config.apiKeys).toEqual({
+      anthropic: "sk-ant-test",
+      openai: "sk-test",
+    });
   });
 
   test("loads both config.json and apiKeys.json", async () => {
@@ -146,11 +152,11 @@ describe("loadConfig", () => {
     await Promise.all([
       Bun.write(
         join(dir, "config.json"),
-        JSON.stringify({ model: "anthropic/claude-sonnet-4-5" })
+        JSON.stringify({ model: "anthropic/claude-sonnet-4-5" }),
       ),
       Bun.write(
         join(dir, "apiKeys.json"),
-        JSON.stringify({ anthropic: "sk-ant-test" })
+        JSON.stringify({ anthropic: "sk-ant-test" }),
       ),
     ]);
 
@@ -161,7 +167,10 @@ describe("loadConfig", () => {
 
   test("loads partial config.json (only model)", async () => {
     const dir = makeTmpDir();
-    await Bun.write(join(dir, "config.json"), JSON.stringify({ model: "google/gemini-2.5-flash" }));
+    await Bun.write(
+      join(dir, "config.json"),
+      JSON.stringify({ model: "google/gemini-2.5-flash" }),
+    );
 
     const config = await loadConfig(dir);
     expect(config.model).toBe("google/gemini-2.5-flash");
@@ -196,7 +205,10 @@ describe("loadConfig", () => {
 
   test("ignores zod-invalid config.json (temperature out of range)", async () => {
     const dir = makeTmpDir();
-    await Bun.write(join(dir, "config.json"), JSON.stringify({ temperature: 5 }));
+    await Bun.write(
+      join(dir, "config.json"),
+      JSON.stringify({ temperature: 5 }),
+    );
 
     const config = await loadConfig(dir);
     expect(config).toEqual({});
@@ -222,7 +234,7 @@ describe("loadConfig", () => {
     const dir = makeTmpDir();
     await Bun.write(
       join(dir, "apiKeys.json"),
-      JSON.stringify({ fakeprovider: "sk-test" })
+      JSON.stringify({ fakeprovider: "sk-test" }),
     );
 
     const config = await loadConfig(dir);
@@ -253,7 +265,10 @@ describe("loadConfig", () => {
     const dir = makeTmpDir();
     await Promise.all([
       Bun.write(join(dir, "config.json"), "bad json"),
-      Bun.write(join(dir, "apiKeys.json"), JSON.stringify({ openai: "sk-test" })),
+      Bun.write(
+        join(dir, "apiKeys.json"),
+        JSON.stringify({ openai: "sk-test" }),
+      ),
     ]);
 
     const config = await loadConfig(dir);
@@ -264,7 +279,10 @@ describe("loadConfig", () => {
   test("invalid apiKeys.json does not affect valid config.json", async () => {
     const dir = makeTmpDir();
     await Promise.all([
-      Bun.write(join(dir, "config.json"), JSON.stringify({ model: "openai/gpt-4o" })),
+      Bun.write(
+        join(dir, "config.json"),
+        JSON.stringify({ model: "openai/gpt-4o" }),
+      ),
       Bun.write(join(dir, "apiKeys.json"), "bad json"),
     ]);
 

--- a/src/__tests__/constants.test.ts
+++ b/src/__tests__/constants.test.ts
@@ -1,5 +1,5 @@
-import { test, expect, describe } from "bun:test";
-import { APP, AppSchema, ShellSchema, type Shell, type AppConfig } from "../constants.ts";
+import { describe, expect, test } from "bun:test";
+import { APP, AppSchema, ShellSchema } from "../constants.ts";
 
 describe("APP", () => {
   test("validates against AppSchema", () => {

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1,8 +1,15 @@
-import { test, expect, describe } from "bun:test";
-import { join } from "node:path";
+import { describe, expect, test } from "bun:test";
 import { tmpdir } from "node:os";
-import { buildPrompt, readFiles, resolveOptions, CLIOptionsSchema, JsonOutputSchema, type CLIOptions } from "../index.ts";
+import { join } from "node:path";
 import type { Config } from "../config.ts";
+import {
+  buildPrompt,
+  type CLIOptions,
+  CLIOptionsSchema,
+  JsonOutputSchema,
+  readFiles,
+  resolveOptions,
+} from "../index.ts";
 
 // ── buildPrompt ────────────────────────────────────────────────────────
 
@@ -25,7 +32,7 @@ describe("buildPrompt", () => {
   });
 
   test("arg prompt comes first in combined output", () => {
-    const result = buildPrompt("summarize", null, "long document text")!;
+    const result = buildPrompt("summarize", null, "long document text");
     expect(result.startsWith("summarize")).toBe(true);
     expect(result.endsWith("long document text")).toBe(true);
   });
@@ -41,7 +48,11 @@ describe("buildPrompt", () => {
   });
 
   test("includes file content between arg and stdin", () => {
-    const result = buildPrompt("review", "# file.ts\n```\ncode\n```", "stdin data");
+    const result = buildPrompt(
+      "review",
+      "# file.ts\n```\ncode\n```",
+      "stdin data",
+    );
     expect(result).toBe("review\n\n# file.ts\n```\ncode\n```\n\nstdin data");
   });
 
@@ -84,7 +95,10 @@ describe("readFiles", () => {
   });
 
   test("throws on nonexistent file", async () => {
-    expect(readFiles(["/nonexistent/file.txt"])).rejects.toThrow("File not found: /nonexistent/file.txt");
+    const missing = join(tmpdir(), `nonexistent-${uid()}.txt`);
+    await expect(readFiles([missing])).rejects.toThrow(
+      `File not found: ${missing}`,
+    );
   });
 
   test("reads multiple files", async () => {
@@ -164,7 +178,12 @@ describe("resolveOptions", () => {
   });
 
   test("all undefined opts fall through to config", () => {
-    const config: Config = { model: "xai/grok-3", system: "sys", temperature: 1.5, maxOutputTokens: 300 };
+    const config: Config = {
+      model: "xai/grok-3",
+      system: "sys",
+      temperature: 1.5,
+      maxOutputTokens: 300,
+    };
     const result = resolveOptions(defaultOpts, config);
     expect(result.modelString).toBe("xai/grok-3");
     expect(result.system).toBe("sys");
@@ -200,31 +219,41 @@ describe("CLIOptionsSchema", () => {
 
   test("rejects temperature below 0", () => {
     expect(
-      CLIOptionsSchema.safeParse({ json: false, stream: true, temperature: -1 }).success
+      CLIOptionsSchema.safeParse({ json: false, stream: true, temperature: -1 })
+        .success,
     ).toBe(false);
   });
 
   test("rejects temperature above 2", () => {
     expect(
-      CLIOptionsSchema.safeParse({ json: false, stream: true, temperature: 3 }).success
+      CLIOptionsSchema.safeParse({ json: false, stream: true, temperature: 3 })
+        .success,
     ).toBe(false);
   });
 
   test("rejects negative maxOutputTokens", () => {
     expect(
-      CLIOptionsSchema.safeParse({ json: false, stream: true, maxOutputTokens: -5 }).success
+      CLIOptionsSchema.safeParse({
+        json: false,
+        stream: true,
+        maxOutputTokens: -5,
+      }).success,
     ).toBe(false);
   });
 
   test("rejects float maxOutputTokens", () => {
     expect(
-      CLIOptionsSchema.safeParse({ json: false, stream: true, maxOutputTokens: 10.5 }).success
+      CLIOptionsSchema.safeParse({
+        json: false,
+        stream: true,
+        maxOutputTokens: 10.5,
+      }).success,
     ).toBe(false);
   });
 
   test("rejects non-boolean json", () => {
     expect(
-      CLIOptionsSchema.safeParse({ json: "yes", stream: true }).success
+      CLIOptionsSchema.safeParse({ json: "yes", stream: true }).success,
     ).toBe(false);
   });
 
@@ -277,7 +306,11 @@ describe("JsonOutputSchema", () => {
         inputTokens: 5,
         outputTokens: 10,
         totalTokens: 15,
-        inputTokenDetails: { noCacheTokens: 3, cacheReadTokens: 2, cacheWriteTokens: 0 },
+        inputTokenDetails: {
+          noCacheTokens: 3,
+          cacheReadTokens: 2,
+          cacheWriteTokens: 0,
+        },
         outputTokenDetails: { textTokens: 8, reasoningTokens: 2 },
       },
       finishReason: "stop",
@@ -292,7 +325,7 @@ describe("JsonOutputSchema", () => {
         model: "openai/gpt-4o",
         usage: {},
         finishReason: "stop",
-      }).success
+      }).success,
     ).toBe(false);
   });
 
@@ -302,7 +335,7 @@ describe("JsonOutputSchema", () => {
         text: "hi",
         usage: {},
         finishReason: "stop",
-      }).success
+      }).success,
     ).toBe(false);
   });
 
@@ -312,7 +345,7 @@ describe("JsonOutputSchema", () => {
         text: "hi",
         model: "m",
         usage: {},
-      }).success
+      }).success,
     ).toBe(false);
   });
 });

--- a/src/__tests__/provider.test.ts
+++ b/src/__tests__/provider.test.ts
@@ -1,13 +1,13 @@
-import { test, expect, describe, afterEach } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 import {
+  ModelStringSchema,
+  PROVIDER_ENV_VARS,
+  type ProviderId,
+  ProviderIdSchema,
   parseModel,
+  registry,
   resolveModel,
   SUPPORTED_PROVIDERS,
-  PROVIDER_ENV_VARS,
-  registry,
-  ModelStringSchema,
-  ProviderIdSchema,
-  type ProviderId,
 } from "../provider.ts";
 
 // ── ModelStringSchema ──────────────────────────────────────────────────
@@ -72,21 +72,76 @@ describe("ProviderIdSchema", () => {
 describe("parseModel", () => {
   const cases: Array<[string, string, string, string]> = [
     ["openai/gpt-4o", "openai", "gpt-4o", "openai/gpt-4o"],
-    ["anthropic/claude-sonnet-4-5", "anthropic", "claude-sonnet-4-5", "anthropic/claude-sonnet-4-5"],
-    ["google/gemini-2.5-flash", "google", "gemini-2.5-flash", "google/gemini-2.5-flash"],
+    [
+      "anthropic/claude-sonnet-4-5",
+      "anthropic",
+      "claude-sonnet-4-5",
+      "anthropic/claude-sonnet-4-5",
+    ],
+    [
+      "google/gemini-2.5-flash",
+      "google",
+      "gemini-2.5-flash",
+      "google/gemini-2.5-flash",
+    ],
     ["perplexity/sonar", "perplexity", "sonar", "perplexity/sonar"],
     ["xai/grok-3", "xai", "grok-3", "xai/grok-3"],
-    ["mistral/mistral-large-latest", "mistral", "mistral-large-latest", "mistral/mistral-large-latest"],
-    ["groq/llama-3.3-70b-versatile", "groq", "llama-3.3-70b-versatile", "groq/llama-3.3-70b-versatile"],
-    ["deepseek/deepseek-chat", "deepseek", "deepseek-chat", "deepseek/deepseek-chat"],
-    ["cohere/command-r-plus", "cohere", "command-r-plus", "cohere/command-r-plus"],
-    ["openrouter/openrouter", "openrouter", "openrouter", "openrouter/openrouter"],
+    [
+      "mistral/mistral-large-latest",
+      "mistral",
+      "mistral-large-latest",
+      "mistral/mistral-large-latest",
+    ],
+    [
+      "groq/llama-3.3-70b-versatile",
+      "groq",
+      "llama-3.3-70b-versatile",
+      "groq/llama-3.3-70b-versatile",
+    ],
+    [
+      "deepseek/deepseek-chat",
+      "deepseek",
+      "deepseek-chat",
+      "deepseek/deepseek-chat",
+    ],
+    [
+      "cohere/command-r-plus",
+      "cohere",
+      "command-r-plus",
+      "cohere/command-r-plus",
+    ],
+    [
+      "openrouter/openrouter",
+      "openrouter",
+      "openrouter",
+      "openrouter/openrouter",
+    ],
     ["azure/azure-model-id", "azure", "azure-model-id", "azure/azure-model-id"],
-    ["togetherai/meta-llama/Llama-3.3-70b-Instruct", "togetherai", "meta-llama/Llama-3.3-70b-Instruct", "togetherai/meta-llama/Llama-3.3-70b-Instruct"],
-    ["bedrock/anthropic.claude-sonnet-4-2025-02-19", "bedrock", "anthropic.claude-sonnet-4-2025-02-19", "bedrock/anthropic.claude-sonnet-4-2025-02-19"],
-    ["vertex/google/cloud/llama-3.1", "vertex", "google/cloud/llama-3.1", "vertex/google/cloud/llama-3.1"],
+    [
+      "togetherai/meta-llama/Llama-3.3-70b-Instruct",
+      "togetherai",
+      "meta-llama/Llama-3.3-70b-Instruct",
+      "togetherai/meta-llama/Llama-3.3-70b-Instruct",
+    ],
+    [
+      "bedrock/anthropic.claude-sonnet-4-2025-02-19",
+      "bedrock",
+      "anthropic.claude-sonnet-4-2025-02-19",
+      "bedrock/anthropic.claude-sonnet-4-2025-02-19",
+    ],
+    [
+      "vertex/google/cloud/llama-3.1",
+      "vertex",
+      "google/cloud/llama-3.1",
+      "vertex/google/cloud/llama-3.1",
+    ],
     ["ollama/llama3", "ollama", "llama3", "ollama/llama3"],
-    ["huggingface/meta-llama/Llama-3.3-70b-Instruct", "huggingface", "meta-llama/Llama-3.3-70b-Instruct", "huggingface/meta-llama/Llama-3.3-70b-Instruct"],
+    [
+      "huggingface/meta-llama/Llama-3.3-70b-Instruct",
+      "huggingface",
+      "meta-llama/Llama-3.3-70b-Instruct",
+      "huggingface/meta-llama/Llama-3.3-70b-Instruct",
+    ],
   ];
 
   for (const [input, provider, modelId, fullId] of cases) {
@@ -124,7 +179,24 @@ describe("SUPPORTED_PROVIDERS", () => {
   });
 
   test("includes all expected providers", () => {
-    const expected: ProviderId[] = ["openai", "anthropic", "google", "perplexity", "xai", "mistral", "groq", "deepseek", "cohere", "openrouter", "azure", "togetherai", "bedrock", "vertex", "ollama", "huggingface"];
+    const expected: ProviderId[] = [
+      "openai",
+      "anthropic",
+      "google",
+      "perplexity",
+      "xai",
+      "mistral",
+      "groq",
+      "deepseek",
+      "cohere",
+      "openrouter",
+      "azure",
+      "togetherai",
+      "bedrock",
+      "vertex",
+      "ollama",
+      "huggingface",
+    ];
     for (const p of expected) {
       expect(SUPPORTED_PROVIDERS).toContain(p);
     }
@@ -194,23 +266,108 @@ describe("resolveModel", () => {
     process.env = { ...originalEnv };
   });
 
-  const providerCases: Array<{ provider: ProviderId; model: string; envVars: string[]; expectedModelId: string }> = [
-    { provider: "openai", model: "openai/gpt-4o", envVars: ["OPENAI_API_KEY"], expectedModelId: "gpt-4o" },
-    { provider: "anthropic", model: "anthropic/claude-sonnet-4-5", envVars: ["ANTHROPIC_API_KEY"], expectedModelId: "claude-sonnet-4-5" },
-    { provider: "google", model: "google/gemini-2.5-flash", envVars: ["GOOGLE_GENERATIVE_AI_API_KEY"], expectedModelId: "gemini-2.5-flash" },
-    { provider: "perplexity", model: "perplexity/sonar", envVars: ["PERPLEXITY_API_KEY"], expectedModelId: "sonar" },
-    { provider: "xai", model: "xai/grok-3", envVars: ["XAI_API_KEY"], expectedModelId: "grok-3" },
-    { provider: "mistral", model: "mistral/mistral-large-latest", envVars: ["MISTRAL_API_KEY"], expectedModelId: "mistral-large-latest" },
-    { provider: "groq", model: "groq/llama-3.3-70b-versatile", envVars: ["GROQ_API_KEY"], expectedModelId: "llama-3.3-70b-versatile" },
-    { provider: "deepseek", model: "deepseek/deepseek-chat", envVars: ["DEEPSEEK_API_KEY"], expectedModelId: "deepseek-chat" },
-    { provider: "cohere", model: "cohere/command-r-plus", envVars: ["COHERE_API_KEY"], expectedModelId: "command-r-plus" },
-    { provider: "openrouter", model: "openrouter/openrouter", envVars: ["OPENROUTER_API_KEY"], expectedModelId: "openrouter" },
-    { provider: "azure", model: "azure/azure-model-id", envVars: ["AZURE_AI_API_KEY"], expectedModelId: "azure-model-id" },
-    { provider: "togetherai", model: "togetherai/meta-llama/Llama-3.3-70b-Instruct", envVars: ["TOGETHERAI_API_KEY"], expectedModelId: "meta-llama/Llama-3.3-70b-Instruct" },
-    { provider: "bedrock", model: "bedrock/anthropic.claude-sonnet-4-2025-02-19", envVars: ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"], expectedModelId: "anthropic.claude-sonnet-4-2025-02-19" },
-    { provider: "vertex", model: "vertex/google/cloud/llama-3.1", envVars: ["GOOGLE_VERTEX_PROJECT", "GOOGLE_VERTEX_LOCATION"], expectedModelId: "google/cloud/llama-3.1" },
-    { provider: "ollama", model: "ollama/llama3", envVars: ["OLLAMA_HOST"], expectedModelId: "llama3" },
-    { provider: "huggingface", model: "huggingface/meta-llama/Llama-3.3-70b-Instruct", envVars: ["HF_TOKEN"], expectedModelId: "meta-llama/Llama-3.3-70b-Instruct" },
+  const providerCases: Array<{
+    provider: ProviderId;
+    model: string;
+    envVars: string[];
+    expectedModelId: string;
+  }> = [
+    {
+      provider: "openai",
+      model: "openai/gpt-4o",
+      envVars: ["OPENAI_API_KEY"],
+      expectedModelId: "gpt-4o",
+    },
+    {
+      provider: "anthropic",
+      model: "anthropic/claude-sonnet-4-5",
+      envVars: ["ANTHROPIC_API_KEY"],
+      expectedModelId: "claude-sonnet-4-5",
+    },
+    {
+      provider: "google",
+      model: "google/gemini-2.5-flash",
+      envVars: ["GOOGLE_GENERATIVE_AI_API_KEY"],
+      expectedModelId: "gemini-2.5-flash",
+    },
+    {
+      provider: "perplexity",
+      model: "perplexity/sonar",
+      envVars: ["PERPLEXITY_API_KEY"],
+      expectedModelId: "sonar",
+    },
+    {
+      provider: "xai",
+      model: "xai/grok-3",
+      envVars: ["XAI_API_KEY"],
+      expectedModelId: "grok-3",
+    },
+    {
+      provider: "mistral",
+      model: "mistral/mistral-large-latest",
+      envVars: ["MISTRAL_API_KEY"],
+      expectedModelId: "mistral-large-latest",
+    },
+    {
+      provider: "groq",
+      model: "groq/llama-3.3-70b-versatile",
+      envVars: ["GROQ_API_KEY"],
+      expectedModelId: "llama-3.3-70b-versatile",
+    },
+    {
+      provider: "deepseek",
+      model: "deepseek/deepseek-chat",
+      envVars: ["DEEPSEEK_API_KEY"],
+      expectedModelId: "deepseek-chat",
+    },
+    {
+      provider: "cohere",
+      model: "cohere/command-r-plus",
+      envVars: ["COHERE_API_KEY"],
+      expectedModelId: "command-r-plus",
+    },
+    {
+      provider: "openrouter",
+      model: "openrouter/openrouter",
+      envVars: ["OPENROUTER_API_KEY"],
+      expectedModelId: "openrouter",
+    },
+    {
+      provider: "azure",
+      model: "azure/azure-model-id",
+      envVars: ["AZURE_AI_API_KEY"],
+      expectedModelId: "azure-model-id",
+    },
+    {
+      provider: "togetherai",
+      model: "togetherai/meta-llama/Llama-3.3-70b-Instruct",
+      envVars: ["TOGETHERAI_API_KEY"],
+      expectedModelId: "meta-llama/Llama-3.3-70b-Instruct",
+    },
+    {
+      provider: "bedrock",
+      model: "bedrock/anthropic.claude-sonnet-4-2025-02-19",
+      envVars: ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"],
+      expectedModelId: "anthropic.claude-sonnet-4-2025-02-19",
+    },
+    {
+      provider: "vertex",
+      model: "vertex/google/cloud/llama-3.1",
+      envVars: ["GOOGLE_VERTEX_PROJECT", "GOOGLE_VERTEX_LOCATION"],
+      expectedModelId: "google/cloud/llama-3.1",
+    },
+    {
+      provider: "ollama",
+      model: "ollama/llama3",
+      envVars: ["OLLAMA_HOST"],
+      expectedModelId: "llama3",
+    },
+    {
+      provider: "huggingface",
+      model: "huggingface/meta-llama/Llama-3.3-70b-Instruct",
+      envVars: ["HF_TOKEN"],
+      expectedModelId: "meta-llama/Llama-3.3-70b-Instruct",
+    },
   ];
 
   for (const { provider, model, envVars, expectedModelId } of providerCases) {

--- a/src/__tests__/sdk-compat.test.ts
+++ b/src/__tests__/sdk-compat.test.ts
@@ -1,8 +1,13 @@
-import { test, expect, describe } from "bun:test";
-import type { LanguageModelUsage, FinishReason } from "ai";
-import { streamText, generateText } from "ai";
-import { JsonOutputSchema, type JsonOutput } from "../index.ts";
-import { registry, SUPPORTED_PROVIDERS, PROVIDER_ENV_VARS, type ProviderId } from "../provider.ts";
+import { describe, expect, test } from "bun:test";
+import type { FinishReason, LanguageModelUsage } from "ai";
+import { generateText, streamText } from "ai";
+import { type JsonOutput, JsonOutputSchema } from "../index.ts";
+import {
+  PROVIDER_ENV_VARS,
+  type ProviderId,
+  registry,
+  SUPPORTED_PROVIDERS,
+} from "../provider.ts";
 
 // ── AI SDK type alignment ─────────────────────────────────────────────
 //
@@ -19,7 +24,11 @@ describe("AI SDK type compatibility", () => {
       inputTokens: 10,
       outputTokens: 20,
       totalTokens: 30,
-      inputTokenDetails: { noCacheTokens: 2, cacheReadTokens: 5, cacheWriteTokens: 3 },
+      inputTokenDetails: {
+        noCacheTokens: 2,
+        cacheReadTokens: 5,
+        cacheWriteTokens: 3,
+      },
       outputTokenDetails: { textTokens: 12, reasoningTokens: 8 },
     };
 
@@ -72,7 +81,11 @@ describe("AI SDK type compatibility", () => {
         inputTokens: 5,
         outputTokens: 3,
         totalTokens: 8,
-        inputTokenDetails: { noCacheTokens: 5, cacheReadTokens: 0, cacheWriteTokens: 0 },
+        inputTokenDetails: {
+          noCacheTokens: 5,
+          cacheReadTokens: 0,
+          cacheWriteTokens: 0,
+        },
         outputTokenDetails: { textTokens: 3, reasoningTokens: 0 },
       } satisfies LanguageModelUsage,
       finishReason: "stop" as FinishReason,
@@ -119,10 +132,12 @@ describe("AI SDK registry compatibility", () => {
     // so we skip providers that throw LoadSettingError.
     for (const provider of SUPPORTED_PROVIDERS) {
       try {
-        registry.languageModel(`${provider}/test-model` as `${ProviderId}/${string}`);
-      } catch (e: any) {
+        registry.languageModel(
+          `${provider}/test-model` as `${ProviderId}/${string}`,
+        );
+      } catch (e: unknown) {
         // Allow LoadSettingError (missing env config), but fail on other errors
-        expect(e.name).toBe("AI_LoadSettingError");
+        expect((e as Error).name).toBe("AI_LoadSettingError");
       }
     }
   });

--- a/src/completions.ts
+++ b/src/completions.ts
@@ -1,5 +1,5 @@
+import { APP, type Shell, ShellSchema } from "./constants.ts";
 import { SUPPORTED_PROVIDERS } from "./provider.ts";
-import { APP, ShellSchema, type Shell } from "./constants.ts";
 
 const providers = SUPPORTED_PROVIDERS.join(" ");
 const shells = APP.supportedShells.join(" ");
@@ -9,9 +9,7 @@ const funcName = APP.name.replace(/-/g, "_");
 export function generateCompletions(shell: string): string {
   const result = ShellSchema.safeParse(shell);
   if (!result.success) {
-    console.error(
-      `Error: Unknown shell "${shell}". Supported: ${shells}`
-    );
+    console.error(`Error: Unknown shell "${shell}". Supported: ${shells}`);
     process.exit(1);
   }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,26 +1,40 @@
-import { z } from "zod";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { ProviderIdSchema, SUPPORTED_PROVIDERS } from "./provider.ts";
+import { z } from "zod";
 import { APP } from "./constants.ts";
+import { ProviderIdSchema, SUPPORTED_PROVIDERS } from "./provider.ts";
 
-const ApiKeysSchema = z.record(z.string(), z.string()).refine(
-  (obj) => Object.keys(obj).every((k) => ProviderIdSchema.safeParse(k).success),
-  { message: `apiKeys keys must be valid providers: ${SUPPORTED_PROVIDERS.join(", ")}` }
-);
+const ApiKeysSchema = z
+  .record(z.string(), z.string())
+  .refine(
+    (obj) =>
+      Object.keys(obj).every((k) => ProviderIdSchema.safeParse(k).success),
+    {
+      message: `apiKeys keys must be valid providers: ${SUPPORTED_PROVIDERS.join(", ")}`,
+    },
+  );
 
 export const ConfigSchema = z.object({
   model: z.string().optional(),
   system: z.string().optional(),
-  temperature: z.number().min(APP.temperature.min).max(APP.temperature.max).optional(),
+  temperature: z
+    .number()
+    .min(APP.temperature.min)
+    .max(APP.temperature.max)
+    .optional(),
   maxOutputTokens: z.number().int().positive().optional(),
 });
 
-export type Config = z.infer<typeof ConfigSchema> & { apiKeys?: Record<string, string> };
+export type Config = z.infer<typeof ConfigSchema> & {
+  apiKeys?: Record<string, string>;
+};
 
 const DEFAULT_CONFIG_DIR = join(homedir(), APP.configDirName);
 
-async function loadJsonFile<T>(path: string, schema: z.ZodType<T>): Promise<T | null> {
+async function loadJsonFile<T>(
+  path: string,
+  schema: z.ZodType<T>,
+): Promise<T | null> {
   const file = Bun.file(path);
   if (!(await file.exists())) return null;
   try {

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -1,29 +1,46 @@
-import { z } from "zod";
-import { createProviderRegistry } from "ai";
-import type { ProviderV3 } from "@ai-sdk/provider";
-import { APP } from "./constants.ts";
-import { openai } from "@ai-sdk/openai";
-import { anthropic } from "@ai-sdk/anthropic";
-import { google } from "@ai-sdk/google";
-import { perplexity } from "@ai-sdk/perplexity";
-import { xai } from "@ai-sdk/xai";
-import { mistral } from "@ai-sdk/mistral";
-import { groq } from "@ai-sdk/groq";
-import { deepseek } from "@ai-sdk/deepseek";
-import { cohere } from "@ai-sdk/cohere";
-import { openrouter } from "@openrouter/ai-sdk-provider";
-import { azure } from "@ai-sdk/azure";
-import { togetherai } from "@ai-sdk/togetherai";
 import { bedrock } from "@ai-sdk/amazon-bedrock";
+import { anthropic } from "@ai-sdk/anthropic";
+import { azure } from "@ai-sdk/azure";
+import { cohere } from "@ai-sdk/cohere";
+import { deepseek } from "@ai-sdk/deepseek";
+import { google } from "@ai-sdk/google";
 import { vertex } from "@ai-sdk/google-vertex";
-import { ollama } from "ai-sdk-ollama";
+import { groq } from "@ai-sdk/groq";
 import { huggingface } from "@ai-sdk/huggingface";
+import { mistral } from "@ai-sdk/mistral";
+import { openai } from "@ai-sdk/openai";
+import { perplexity } from "@ai-sdk/perplexity";
+import type { ProviderV3 } from "@ai-sdk/provider";
+import { togetherai } from "@ai-sdk/togetherai";
+import { xai } from "@ai-sdk/xai";
+import { openrouter } from "@openrouter/ai-sdk-provider";
+import { createProviderRegistry } from "ai";
+import { ollama } from "ai-sdk-ollama";
+import { z } from "zod";
+import { APP } from "./constants.ts";
 
 const openrouterProvider = openrouter as unknown as ProviderV3;
 
 export const registry = createProviderRegistry(
-  { openai, anthropic, google, perplexity, xai, mistral, groq, deepseek, cohere, openrouter: openrouterProvider, azure, togetherai, bedrock, vertex, ollama, huggingface },
-  { separator: "/" }
+  {
+    openai,
+    anthropic,
+    google,
+    perplexity,
+    xai,
+    mistral,
+    groq,
+    deepseek,
+    cohere,
+    openrouter: openrouterProvider,
+    azure,
+    togetherai,
+    bedrock,
+    vertex,
+    ollama,
+    huggingface,
+  },
+  { separator: "/" },
 );
 
 export const SUPPORTED_PROVIDERS = Object.freeze([
@@ -74,7 +91,11 @@ export const ModelStringSchema = z
   .transform((val) => {
     const slashIndex = val.indexOf("/");
     if (slashIndex === -1) {
-      return { provider: APP.defaultProvider, modelId: val, fullId: `${APP.defaultProvider}/${val}` };
+      return {
+        provider: APP.defaultProvider,
+        modelId: val,
+        fullId: `${APP.defaultProvider}/${val}`,
+      };
     }
     return {
       provider: val.slice(0, slashIndex),
@@ -96,17 +117,17 @@ export function resolveModel(modelString: string) {
   if (!result.success) {
     const supported = SUPPORTED_PROVIDERS.join(", ");
     console.error(
-      `Error: Unknown provider "${provider}". Supported: ${supported}`
+      `Error: Unknown provider "${provider}". Supported: ${supported}`,
     );
     process.exit(1);
   }
 
   const envVars = PROVIDER_ENV_VARS[result.data];
-  const missingVars = envVars.filter(v => !process.env[v]);
+  const missingVars = envVars.filter((v) => !process.env[v]);
 
   if (missingVars.length > 0) {
     console.error(
-      `Error: Missing required environment variable(s): ${missingVars.join(", ")}. Set them or check your provider config.`
+      `Error: Missing required environment variable(s): ${missingVars.join(", ")}. Set them or check your provider config.`,
     );
     process.exit(1);
   }
@@ -116,20 +137,24 @@ export function resolveModel(modelString: string) {
 
 export function printProviders(): void {
   const maxName = Math.max(...SUPPORTED_PROVIDERS.map((p) => p.length));
-  const maxVar = Math.max(...Object.values(PROVIDER_ENV_VARS).map(vars => vars.join(", ").length));
+  const maxVar = Math.max(
+    ...Object.values(PROVIDER_ENV_VARS).map((vars) => vars.join(", ").length),
+  );
 
   console.log(
-    `${"Provider".padEnd(maxName)}  ${"Env Variable(s)".padEnd(maxVar)}  Status`
+    `${"Provider".padEnd(maxName)}  ${"Env Variable(s)".padEnd(maxVar)}  Status`,
   );
-  console.log(`${"─".repeat(maxName)}  ${"─".repeat(maxVar)}  ${"─".repeat(6)}`);
+  console.log(
+    `${"─".repeat(maxName)}  ${"─".repeat(maxVar)}  ${"─".repeat(6)}`,
+  );
 
   for (const provider of SUPPORTED_PROVIDERS) {
     const envVars = PROVIDER_ENV_VARS[provider];
     const envVarStr = envVars.join(", ");
-    const allSet = envVars.every(v => !!process.env[v]);
+    const allSet = envVars.every((v) => !!process.env[v]);
     const status = allSet ? "✓ set" : "✗ missing";
     console.log(
-      `${provider.padEnd(maxName)}  ${envVarStr.padEnd(maxVar)}  ${status}`
+      `${provider.padEnd(maxName)}  ${envVarStr.padEnd(maxVar)}  ${status}`,
     );
   }
 }


### PR DESCRIPTION
## Summary
- **Biome** linter/formatter with defaults + `useMaxParams` (max: 3, warn)
- **Lefthook** pre-commit hook runs `biome check --write` on staged `.ts/.js/.json/.css` files
- Applied all Biome formatting and lint fixes across codebase
- Fixed unused imports, `noNonNullAssertion`, `noExplicitAny`
- Added `lint` and `lint:check` scripts to `package.json`
- Addresses remaining PR #19 Copilot feedback (`await` on rejects, tmpdir paths, `setupCLI` returns program)

## Test plan
- [x] `bun test` — 228 tests pass across 7 files
- [x] `bunx biome check .` — clean, no issues
- [x] Lefthook pre-commit hook fires and passes on commit