### PR TITLE
🐛 Fix typecheck: use optional chaining instead of non-null assertion

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -33,8 +33,9 @@ describe("buildPrompt", () => {
 
   test("arg prompt comes first in combined output", () => {
     const result = buildPrompt("summarize", null, "long document text");
-    expect(result.startsWith("summarize")).toBe(true);
-    expect(result.endsWith("long document text")).toBe(true);
+    expect(result).not.toBeNull();
+    expect(result?.startsWith("summarize")).toBe(true);
+    expect(result?.endsWith("long document text")).toBe(true);
   });
 
   test("preserves multiline stdin content", () => {


### PR DESCRIPTION
## Summary
- Fixes CI typecheck failure from PR #22
- `buildPrompt()` returns `string | null` — Biome's `noNonNullAssertion` rule removed the `!` but TypeScript still needs null safety
- Replaced with `?.` optional chaining + explicit `expect(result).not.toBeNull()`

## Test plan
- [x] `bun run typecheck` — clean
- [x] `bun test` — 228 tests pass