### PR TITLE
🔧 Add manual workflow_dispatch trigger to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary
- Adds `workflow_dispatch` trigger to the release workflow
- Allows manually triggering a release from the GitHub Actions UI (Actions tab > Release > Run workflow)
- Tag-based triggers (`v*`) still work as before

## Test plan
- [x] YAML is valid
- [ ] Verify "Run workflow" button appears in Actions tab after merge