### PR TITLE
🐛 Fix version tests: read from package.json instead of hardcoded string

### DIFF
--- a/src/__tests__/cli.test.ts
+++ b/src/__tests__/cli.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { mkdirSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import pkg from "../../package.json";
 
 const CLI = join(import.meta.dir, "..", "index.ts");
 const tmpDir = tmpdir();
@@ -89,13 +90,13 @@ describe("CLI: help and version", () => {
 
   test("prints version with --version", async () => {
     const { stdout, exitCode } = await runCLI(["--version"]);
-    expect(stdout.trim()).toBe("1.0.0");
+    expect(stdout.trim()).toBe(pkg.version);
     expect(exitCode).toBe(0);
   });
 
   test("prints version with -V", async () => {
     const { stdout, exitCode } = await runCLI(["-V"]);
-    expect(stdout.trim()).toBe("1.0.0");
+    expect(stdout.trim()).toBe(pkg.version);
     expect(exitCode).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary
- Version tests were hardcoded to `"1.0.0"` but package.json is now `1.0.1`
- Import `pkg.version` from `package.json` so tests stay correct across version bumps

## Test plan
- [x] `bun test` — 228 tests pass
- [x] `bun run typecheck` — clean