### PR TITLE
🚀 Use bun publish instead of npm publish in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,14 +41,9 @@ jobs:
 
       - run: bun install --frozen-lockfile
 
-      - uses: actions/setup-node@v4
-        with:
-          node-version: "22"
-          registry-url: "https://registry.npmjs.org"
-
-      - run: npm publish
+      - run: bun publish
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   github-release:
     name: GitHub Release


### PR DESCRIPTION
## Summary
- Replace `npm publish` + `actions/setup-node` with `bun publish`
- Removes Node.js as a CI dependency — entire release pipeline is now Bun-native
- Auth token passed via `NPM_CONFIG_TOKEN` (Bun's expected env var for npm registry auth)

## Test plan
- [ ] Trigger release workflow manually to verify `bun publish` works