### PR TITLE
✨ Auto-bump version + use bun pm version in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
           if [ -n "${{ inputs.version }}" ]; then
             VERSION="${{ inputs.version }}"
           else
-            VERSION=$(node -p "require('./package.json').version")
+            VERSION=$(bun -e "console.log(require('./package.json').version)")
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
@@ -93,11 +93,11 @@ jobs:
       - name: Bump version if needed
         if: needs.resolve-version.outputs.version != ''
         run: |
-          CURRENT=$(node -p "require('./package.json').version")
+          CURRENT=$(bun -e "console.log(require('./package.json').version)")
           TARGET="${{ needs.resolve-version.outputs.version }}"
           if [ "$CURRENT" != "$TARGET" ]; then
             echo "Bumping $CURRENT → $TARGET"
-            npm version "$TARGET" --no-git-tag-version
+            bun pm version "$TARGET" --no-git-tag-version
           else
             echo "Already at $TARGET"
           fi


### PR DESCRIPTION
## Summary
- **Auto-bump package.json** when manual dispatch version input differs from current version
- Uses `bun pm version` instead of `npm version` — zero Node.js in the workflow
- Also swaps `node -p` → `bun -e` for reading package.json version
- No bump when version input is empty or matches current — publishes as-is

## Test plan
- [ ] Manual dispatch with `1.0.2` → bumps package.json, publishes, tags, releases
- [ ] Manual dispatch with empty input → uses current version, no bump
- [ ] Tag push still works unchanged