### PR TITLE
📦 Publish to GitHub Packages for repo sidebar visibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ on:
 
 permissions:
   contents: write
+  packages: write
 
 jobs:
   test:
@@ -105,6 +106,36 @@ jobs:
       - run: bun publish
         env:
           NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  publish-github:
+    name: Publish to GitHub Packages
+    needs: [test, resolve-version, publish]
+    if: always() && needs.publish.result == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - run: bun install --frozen-lockfile
+
+      - name: Bump version if needed
+        if: needs.resolve-version.outputs.version != ''
+        run: |
+          CURRENT=$(bun -e "console.log(require('./package.json').version)")
+          TARGET="${{ needs.resolve-version.outputs.version }}"
+          if [ "$CURRENT" != "$TARGET" ]; then
+            bun pm version "$TARGET" --no-git-tag-version
+          fi
+
+      - name: Publish to GitHub Packages
+        run: |
+          bun pm pkg set name="@andrew-bierman/ai-pipe"
+          bun publish --registry https://npm.pkg.github.com
+        env:
+          NPM_CONFIG_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   github-release:
     name: GitHub Release


### PR DESCRIPTION
## Summary
- Adds a `publish-github` job that publishes to GitHub Packages (`npm.pkg.github.com`)
- GitHub Packages requires a scoped name, so it temporarily sets the name to `@andrew-bierman/ai-pipe` before publishing
- npm registry still gets the unscoped `ai-pipe` — no change for npm users
- Adds `packages: write` permission
- Uses `GITHUB_TOKEN` (no extra secrets needed)

## Why
The "Packages" section on the GitHub repo sidebar only shows packages published to GitHub Packages, not npmjs.org. This makes the package visible at https://github.com/andrew-bierman/ai-pipe.

## Test plan
- [ ] Manual dispatch → package appears under repo "Packages" sidebar
- [ ] npm registry still receives unscoped `ai-pipe`