### PR TITLE
📦 Sync package.json version back to repo after publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,7 +140,7 @@ jobs:
   sync-version:
     name: Sync version to repo
     needs: [publish, resolve-version]
-    if: always() && needs.publish.result == 'success' && needs.resolve-version.outputs.version != ''
+    if: always() && needs.publish.result == 'success' && needs.resolve-version.outputs.version != '' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -161,7 +161,8 @@ jobs:
             git config user.email "github-actions[bot]@users.noreply.github.com"
             git add package.json
             git commit -m "📦 Bump version to $TARGET"
-            git push
+            git pull --rebase origin main
+            git push origin HEAD:main
           else
             echo "package.json already at $TARGET"
           fi


### PR DESCRIPTION
## Summary
- After a successful `workflow_dispatch` publish with a version bump, commit the updated `package.json` back to `main` so the repo stays in sync with what's on npm

## How it works
- New `sync-version` job runs after `publish` succeeds
- Only triggers on `workflow_dispatch` when a version was resolved (i.e. `resolve-version.outputs.version` is set)
- Compares current `package.json` version to the target — if different, bumps via `bun pm version`, commits as `github-actions[bot]`, and pushes to `main`
- No-op if already in sync

## Test plan
- [ ] Trigger manual release with a new version, verify package.json is updated on main after publish
- [ ] Trigger manual release with current version, verify no extra commit