### PR TITLE
🐛 Fix sync-version: create PR instead of direct push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,7 +140,7 @@ jobs:
   sync-version:
     name: Sync version to repo
     needs: [publish, resolve-version]
-    if: always() && needs.publish.result == 'success' && needs.resolve-version.outputs.version != '' && github.ref == 'refs/heads/main'
+    if: always() && needs.publish.result == 'success' && needs.resolve-version.outputs.version != ''
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -151,18 +151,23 @@ jobs:
         with:
           bun-version: latest
 
-      - name: Update package.json version
+      - name: Update package.json version via PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           CURRENT=$(bun -e "console.log(require('./package.json').version)")
           TARGET="${{ needs.resolve-version.outputs.version }}"
           if [ "$CURRENT" != "$TARGET" ]; then
+            BRANCH="chore/bump-v$TARGET"
+            git checkout -b "$BRANCH"
             bun pm version "$TARGET" --no-git-tag-version
             git config user.name "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"
             git add package.json
             git commit -m "📦 Bump version to $TARGET"
-            git pull --rebase origin main
-            git push origin HEAD:main
+            git push origin "$BRANCH"
+            gh pr create --title "📦 Bump version to $TARGET" --body "Auto-generated after successful publish of v$TARGET." --base main --head "$BRANCH"
+            gh pr merge "$BRANCH" --squash --auto
           else
             echo "package.json already at $TARGET"
           fi


### PR DESCRIPTION
## Summary
- Branch protection rules block direct pushes to `main` from CI
- Changed `sync-version` job to create a branch (`chore/bump-vX.Y.Z`), open a PR, and auto-merge via `gh pr merge --squash --auto`

## What changed
- Creates a `chore/bump-v$TARGET` branch
- Opens a PR with the version bump
- Uses `gh pr merge --squash --auto` to auto-merge once checks pass

## Test plan
- [ ] Trigger manual release with a new version, verify a PR is created and auto-merged