### PR TITLE
🐛 Add pull-requests permission for version sync

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ on:
 permissions:
   contents: write
   packages: write
+  pull-requests: write
 
 jobs:
   test:


### PR DESCRIPTION
## Summary
- `GITHUB_TOKEN` needs `pull-requests: write` to create and auto-merge the version bump PR
- Fixes: `Resource not accessible by integration (createPullRequest)`

## Test plan
- [ ] Trigger manual release, verify version bump PR is created and auto-merged