### PR TITLE
🐛 Use peter-evans/create-pull-request for version sync

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,26 +152,25 @@ jobs:
         with:
           bun-version: latest
 
-      - name: Update package.json version via PR
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Bump package.json version
         run: |
           CURRENT=$(bun -e "console.log(require('./package.json').version)")
           TARGET="${{ needs.resolve-version.outputs.version }}"
           if [ "$CURRENT" != "$TARGET" ]; then
-            BRANCH="chore/bump-v$TARGET"
-            git checkout -b "$BRANCH"
             bun pm version "$TARGET" --no-git-tag-version
-            git config user.name "github-actions[bot]"
-            git config user.email "github-actions[bot]@users.noreply.github.com"
-            git add package.json
-            git commit -m "📦 Bump version to $TARGET"
-            git push origin "$BRANCH"
-            gh pr create --title "📦 Bump version to $TARGET" --body "Auto-generated after successful publish of v$TARGET." --base main --head "$BRANCH"
-            gh pr merge "$BRANCH" --squash --auto
+            echo "BUMPED=true" >> "$GITHUB_ENV"
           else
             echo "package.json already at $TARGET"
           fi
+
+      - name: Create PR
+        if: env.BUMPED == 'true'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          commit-message: "📦 Bump version to ${{ needs.resolve-version.outputs.version }}"
+          branch: chore/bump-v${{ needs.resolve-version.outputs.version }}
+          title: "📦 Bump version to ${{ needs.resolve-version.outputs.version }}"
+          body: "Auto-generated after successful publish of v${{ needs.resolve-version.outputs.version }}."
 
   github-release:
     name: GitHub Release


### PR DESCRIPTION
## Summary
- Replace manual `gh pr create` (blocked by repo settings) with `peter-evans/create-pull-request@v7`
- This action handles branch creation, commit, push, and PR creation in one step
- No repo settings changes needed — it works with the default `GITHUB_TOKEN`

## Note
You'll still need to **enable "Allow GitHub Actions to create and approve pull requests"** in Settings > Actions > General for this to work. But `peter-evans/create-pull-request` is the standard, battle-tested approach for this pattern.

## Test plan
- [ ] Enable the repo setting, trigger manual release, verify version bump PR is created