### PR TITLE
🐛 Fix shell completions

### DIFF
--- a/src/__tests__/completions.test.ts
+++ b/src/__tests__/completions.test.ts
@@ -19,15 +19,38 @@ describe("generateCompletions", () => {
       expect(result).toContain("--role");
       expect(result).toContain("--roles");
       expect(result).toContain("--file");
+      expect(result).toContain("--image");
       expect(result).toContain("--json");
       expect(result).toContain("--no-stream");
       expect(result).toContain("--temperature");
       expect(result).toContain("--max-output-tokens");
       expect(result).toContain("--config");
+      expect(result).toContain("--cost");
+      expect(result).toContain("--markdown");
+      expect(result).toContain("--session");
       expect(result).toContain("--providers");
       expect(result).toContain("--completions");
       expect(result).toContain("--version");
       expect(result).toContain("--help");
+    });
+
+    test("includes short flags", () => {
+      const result = generateCompletions("bash");
+      for (const flag of [
+        "-m",
+        "-s",
+        "-r",
+        "-f",
+        "-i",
+        "-j",
+        "-t",
+        "-c",
+        "-C",
+        "-V",
+        "-h",
+      ]) {
+        expect(result).toContain(flag);
+      }
     });
 
     test("includes all providers", () => {
@@ -40,6 +63,11 @@ describe("generateCompletions", () => {
     test("includes install instructions", () => {
       const result = generateCompletions("bash");
       expect(result).toContain('eval "$(ai-pipe --completions bash)"');
+    });
+
+    test("registers completions for ai alias", () => {
+      const result = generateCompletions("bash");
+      expect(result).toContain("complete -F _ai_pipe_completions ai");
     });
   });
 
@@ -63,6 +91,25 @@ describe("generateCompletions", () => {
       const result = generateCompletions("zsh");
       expect(result).toContain('eval "$(ai-pipe --completions zsh)"');
     });
+
+    test("does not define phantom -R short flag for --roles", () => {
+      const result = generateCompletions("zsh");
+      expect(result).not.toContain("-R,--roles");
+      expect(result).not.toContain("-R --roles");
+    });
+
+    test("includes new option entries", () => {
+      const result = generateCompletions("zsh");
+      expect(result).toContain("--image");
+      expect(result).toContain("--cost");
+      expect(result).toContain("--markdown");
+      expect(result).toContain("--session");
+    });
+
+    test("registers completions for ai alias", () => {
+      const result = generateCompletions("zsh");
+      expect(result).toContain("compdef _ai_pipe ai");
+    });
   });
 
   // ── fish ─────────────────────────────────────────────────────────
@@ -80,11 +127,15 @@ describe("generateCompletions", () => {
       expect(result).toContain("-l role");
       expect(result).toContain("-l roles");
       expect(result).toContain("-l file");
+      expect(result).toContain("-l image");
       expect(result).toContain("-l json");
       expect(result).toContain("-l no-stream");
       expect(result).toContain("-l temperature");
       expect(result).toContain("-l max-output-tokens");
       expect(result).toContain("-l config");
+      expect(result).toContain("-l cost");
+      expect(result).toContain("-l markdown");
+      expect(result).toContain("-l session");
       expect(result).toContain("-l providers");
       expect(result).toContain("-l completions");
       expect(result).toContain("-l version");
@@ -108,13 +159,22 @@ describe("generateCompletions", () => {
       expect(result).toContain("-s m");
       expect(result).toContain("-s s");
       expect(result).toContain("-s r");
-      expect(result).toContain("-s R");
       expect(result).toContain("-s f");
       expect(result).toContain("-s j");
       expect(result).toContain("-s t");
       expect(result).toContain("-s c");
       expect(result).toContain("-s V");
       expect(result).toContain("-s h");
+    });
+
+    test("does not define phantom -R short flag for --roles", () => {
+      const result = generateCompletions("fish");
+      expect(result).not.toContain("-s R -l roles");
+    });
+
+    test("includes completions for ai alias", () => {
+      const result = generateCompletions("fish");
+      expect(result).toContain("complete -c ai");
     });
   });
 

--- a/src/completions.ts
+++ b/src/completions.ts
@@ -49,7 +49,7 @@ _${funcName}_completions() {
   COMPREPLY=()
   cur="\${COMP_WORDS[COMP_CWORD]}"
   prev="\${COMP_WORDS[COMP_CWORD-1]}"
-  opts="--model --system --role --roles --file --json --no-stream --no-cache --temperature --max-output-tokens --config --providers --completions --no-update-check --version --help"
+  opts="--model -m --system -s --role -r --roles --file -f --image -i --json -j --no-stream --no-cache --temperature -t --max-output-tokens --config -c --cost --markdown --session -C --providers --completions --no-update-check --version -V --help -h"
   providers="${providers}"
 
   case "\${prev}" in
@@ -62,7 +62,7 @@ _${funcName}_completions() {
       compopt -o nospace
       return 0
       ;;
-    -f|--file)
+    -f|--file|-i|--image)
       COMPREPLY=( $(compgen -f -- "\${cur}") )
       return 0
       ;;
@@ -74,7 +74,7 @@ _${funcName}_completions() {
       COMPREPLY=( $(compgen -W "${shells}" -- "\${cur}") )
       return 0
       ;;
-    -s|--system|-r|--role|--roles|-t|--temperature|--max-output-tokens)
+    -C|--session|-s|--system|-r|--role|-t|--temperature|--max-output-tokens)
       return 0
       ;;
   esac
@@ -84,7 +84,8 @@ _${funcName}_completions() {
     return 0
   fi
 }
-complete -F _${funcName}_completions ${name}`;
+complete -F _${funcName}_completions ${name}
+complete -F _${funcName}_completions ai`;
 }
 
 function zsh(): string {
@@ -98,14 +99,18 @@ _${funcName}() {
     '(-m --model)'{-m,--model}'[Model in provider/model-id format]:model:->models' \\
     '(-s --system)'{-s,--system}'[System prompt]:prompt:' \\
     '(-r --role)'{-r,--role}'[Role name from roles directory]:role:' \\
-    '(-R --roles)'{-R,--roles}'[List available roles]' \\
+    '--roles[List available roles]' \\
     '*'{-f,--file}'[Include file contents]:file:_files' \\
+    '*'{-i,--image}'[Include image file (repeatable)]:file:_files' \\
     '(-j --json)'{-j,--json}'[Output full JSON response object]' \\
     '--no-stream[Wait for full response, then print]' \\
     '--no-cache[Disable response caching]' \\
     '(-t --temperature)'{-t,--temperature}'[Sampling temperature (${APP.temperature.min}-${APP.temperature.max})]:temp:' \\
     '--max-output-tokens[Maximum tokens to generate]:tokens:' \\
     '(-c --config)'{-c,--config}'[Path to config directory]:dir:_directories' \\
+    '--cost[Show token usage and cost after response]' \\
+    '--markdown[Render response as formatted markdown]' \\
+    '(-C --session)'{-C,--session}'[Session name for conversation continuity]:session:' \\
     '--providers[List supported providers]' \\
     '--completions[Generate shell completions]:shell:(${shells})' \\
     '--no-update-check[Disable update notifications]' \\
@@ -120,7 +125,8 @@ _${funcName}() {
       ;;
   esac
 }
-compdef _${funcName} ${name}`;
+compdef _${funcName} ${name}
+compdef _${funcName} ai`;
 }
 
 function fish(): string {
@@ -129,17 +135,41 @@ function fish(): string {
 complete -c ${name} -s m -l model -d 'Model in provider/model-id format' -x -a '${SUPPORTED_PROVIDERS.map((p) => `${p}/`).join(" ")}'
 complete -c ${name} -s s -l system -d 'System prompt' -x
 complete -c ${name} -s r -l role -d 'Role name from roles directory' -x
-complete -c ${name} -s R -l roles -d 'List available roles'
+complete -c ${name} -l roles -d 'List available roles'
 complete -c ${name} -s f -l file -d 'Include file contents in prompt (repeatable)' -r -F
+complete -c ${name} -s i -l image -d 'Include image file (repeatable)' -r -F
 complete -c ${name} -s j -l json -d 'Output full JSON response object'
 complete -c ${name} -l no-stream -d 'Wait for full response, then print'
 complete -c ${name} -l no-cache -d 'Disable response caching'
 complete -c ${name} -s t -l temperature -d 'Sampling temperature (${APP.temperature.min}-${APP.temperature.max})' -x
 complete -c ${name} -l max-output-tokens -d 'Maximum tokens to generate' -x
 complete -c ${name} -s c -l config -d 'Path to config directory' -x -a '(__fish_complete_directories)'
+complete -c ${name} -l cost -d 'Show token usage and cost after response'
+complete -c ${name} -l markdown -d 'Render response as formatted markdown'
+complete -c ${name} -s C -l session -d 'Session name for conversation continuity' -x
 complete -c ${name} -l providers -d 'List supported providers'
 complete -c ${name} -l completions -d 'Generate shell completions' -x -a '${shells}'
 complete -c ${name} -l no-update-check -d 'Disable update notifications'
 complete -c ${name} -s V -l version -d 'Print version'
-complete -c ${name} -s h -l help -d 'Print help'`;
+complete -c ${name} -s h -l help -d 'Print help'
+
+# ai alias completions
+complete -c ai -s m -l model -d 'Model in provider/model-id format' -x -a '${SUPPORTED_PROVIDERS.map((p) => `${p}/`).join(" ")}'
+complete -c ai -s s -l system -d 'System prompt' -x
+complete -c ai -s r -l role -d 'Role name from roles directory' -x
+complete -c ai -l roles -d 'List available roles'
+complete -c ai -s f -l file -d 'Include file contents in prompt (repeatable)' -r -F
+complete -c ai -s i -l image -d 'Include image file (repeatable)' -r -F
+complete -c ai -s j -l json -d 'Output full JSON response object'
+complete -c ai -l no-stream -d 'Wait for full response, then print'
+complete -c ai -s t -l temperature -d 'Sampling temperature (${APP.temperature.min}-${APP.temperature.max})' -x
+complete -c ai -l max-output-tokens -d 'Maximum tokens to generate' -x
+complete -c ai -s c -l config -d 'Path to config directory' -x -a '(__fish_complete_directories)'
+complete -c ai -l cost -d 'Show token usage and cost after response'
+complete -c ai -l markdown -d 'Render response as formatted markdown'
+complete -c ai -s C -l session -d 'Session name for conversation continuity' -x
+complete -c ai -l providers -d 'List supported providers'
+complete -c ai -l completions -d 'Generate shell completions' -x -a '${shells}'
+complete -c ai -s V -l version -d 'Print version'
+complete -c ai -s h -l help -d 'Print help'`;
 }


### PR DESCRIPTION
## Summary
Fixes 8 issues with shell tab completions:

1. **Added missing options** to all shells: `--image`, `--cost`, `--markdown`, `--session`
2. **Added short flags** to bash opts: `-m`, `-s`, `-r`, `-f`, `-i`, `-j`, `-t`, `-c`, `-C`, `-V`, `-h`
3. **Fixed --roles** in wrong bash case branch (was suppressing further completion)
4. **Added bash handlers** for `--image` (file completion) and `--session`
5. **Fixed phantom -R flag** in zsh (CLI doesn't define `-R`)
6. **Added \`ai\` alias** completions for all 3 shells (package defines both \`ai-pipe\` and \`ai\`)
7. **Added zsh entries** for missing options
8. **Added fish entries** for missing options

## Test plan
- [x] `bun test` passes (18 completion tests)
- [ ] Test bash: `eval "$(ai-pipe --completions bash)"` then tab-complete
- [ ] Test zsh: `eval "$(ai-pipe --completions zsh)"` then tab-complete
- [ ] Test fish: completions register for both `ai-pipe` and `ai`