### PR TITLE
✨ Add provider-specific defaults in config

### DIFF
--- a/src/__tests__/cache.test.ts
+++ b/src/__tests__/cache.test.ts
@@ -1,8 +1,6 @@
 import { afterAll, describe, expect, test } from "bun:test";
-import { join } from "node:path";
 import {
   buildCacheKey,
-  type CachedResponse,
   CachedResponseSchema,
   type CacheKeyParams,
   clearCache,
@@ -146,7 +144,12 @@ describe("setCachedResponse + getCachedResponse roundtrip", () => {
     const { homedir } = await import("node:os");
     const { join } = await import("node:path");
     const { unlink } = await import("node:fs/promises");
-    const filePath = join(homedir(), APP.configDirName, "cache", `${testKey}.json`);
+    const filePath = join(
+      homedir(),
+      APP.configDirName,
+      "cache",
+      `${testKey}.json`,
+    );
     try {
       await unlink(filePath);
     } catch {
@@ -166,12 +169,12 @@ describe("setCachedResponse + getCachedResponse roundtrip", () => {
     const cached = await getCachedResponse(testKey);
 
     expect(cached).not.toBeNull();
-    expect(cached!.text).toBe(responseData.text);
-    expect(cached!.usage.inputTokens).toBe(15);
-    expect(cached!.usage.outputTokens).toBe(25);
-    expect(cached!.finishReason).toBe("stop");
-    expect(cached!.model).toBe("openai/gpt-4o");
-    expect(cached!.timestamp).toBeGreaterThan(0);
+    expect(cached?.text).toBe(responseData.text);
+    expect(cached?.usage.inputTokens).toBe(15);
+    expect(cached?.usage.outputTokens).toBe(25);
+    expect(cached?.finishReason).toBe("stop");
+    expect(cached?.model).toBe("openai/gpt-4o");
+    expect(cached?.timestamp).toBeGreaterThan(0);
   });
 });
 
@@ -184,7 +187,12 @@ describe("TTL expiration", () => {
     const { homedir } = await import("node:os");
     const { join } = await import("node:path");
     const { unlink } = await import("node:fs/promises");
-    const filePath = join(homedir(), APP.configDirName, "cache", `${testKey}.json`);
+    const filePath = join(
+      homedir(),
+      APP.configDirName,
+      "cache",
+      `${testKey}.json`,
+    );
     try {
       await unlink(filePath);
     } catch {
@@ -220,7 +228,7 @@ describe("TTL expiration", () => {
     // With a large TTL, the entry should still be valid
     const cached = await getCachedResponse(testKey, 60 * 60 * 1000);
     expect(cached).not.toBeNull();
-    expect(cached!.text).toBe("Fresh response");
+    expect(cached?.text).toBe("Fresh response");
   });
 });
 

--- a/src/__tests__/cost.test.ts
+++ b/src/__tests__/cost.test.ts
@@ -223,10 +223,14 @@ describe("calculateCost", () => {
   });
 
   test("handles unknown provider with tokens", () => {
-    const cost = calculateCost({ provider: "nonexistent", modelId: "model", usage: {
-      inputTokens: 1000,
-      outputTokens: 1000,
-    }});
+    const cost = calculateCost({
+      provider: "nonexistent",
+      modelId: "model",
+      usage: {
+        inputTokens: 1000,
+        outputTokens: 1000,
+      },
+    });
     expect(cost.inputCost).toBe(0);
     expect(cost.outputCost).toBe(0);
     expect(cost.totalCost).toBe(0);
@@ -235,9 +239,13 @@ describe("calculateCost", () => {
   });
 
   test("handles undefined inputTokens but defined outputTokens", () => {
-    const cost = calculateCost({ provider: "openai", modelId: "gpt-4o", usage: {
-      outputTokens: 500,
-    }});
+    const cost = calculateCost({
+      provider: "openai",
+      modelId: "gpt-4o",
+      usage: {
+        outputTokens: 500,
+      },
+    });
     expect(cost.inputTokens).toBe(0);
     expect(cost.inputCost).toBe(0);
     expect(cost.outputTokens).toBe(500);
@@ -245,9 +253,13 @@ describe("calculateCost", () => {
   });
 
   test("handles defined inputTokens but undefined outputTokens", () => {
-    const cost = calculateCost({ provider: "openai", modelId: "gpt-4o", usage: {
-      inputTokens: 500,
-    }});
+    const cost = calculateCost({
+      provider: "openai",
+      modelId: "gpt-4o",
+      usage: {
+        inputTokens: 500,
+      },
+    });
     expect(cost.inputTokens).toBe(500);
     expect(cost.inputCost).toBeGreaterThan(0);
     expect(cost.outputTokens).toBe(0);
@@ -255,39 +267,55 @@ describe("calculateCost", () => {
   });
 
   test("calculates cost for Google Gemini Flash (cheap model)", () => {
-    const cost = calculateCost({ provider: "google", modelId: "gemini-2.5-flash", usage: {
-      inputTokens: 1_000_000,
-      outputTokens: 1_000_000,
-    }});
+    const cost = calculateCost({
+      provider: "google",
+      modelId: "gemini-2.5-flash",
+      usage: {
+        inputTokens: 1_000_000,
+        outputTokens: 1_000_000,
+      },
+    });
     expect(cost.inputCost).toBeCloseTo(0.075, 5);
     expect(cost.outputCost).toBeCloseTo(0.3, 5);
   });
 
   test("calculates cost for 1M tokens exactly", () => {
-    const cost = calculateCost({ provider: "openai", modelId: "gpt-4o", usage: {
-      inputTokens: 1_000_000,
-      outputTokens: 1_000_000,
-    }});
+    const cost = calculateCost({
+      provider: "openai",
+      modelId: "gpt-4o",
+      usage: {
+        inputTokens: 1_000_000,
+        outputTokens: 1_000_000,
+      },
+    });
     expect(cost.inputCost).toBe(2.5);
     expect(cost.outputCost).toBe(10.0);
     expect(cost.totalCost).toBe(12.5);
   });
 
   test("handles very small token counts", () => {
-    const cost = calculateCost({ provider: "openai", modelId: "gpt-4o", usage: {
-      inputTokens: 1,
-      outputTokens: 1,
-    }});
+    const cost = calculateCost({
+      provider: "openai",
+      modelId: "gpt-4o",
+      usage: {
+        inputTokens: 1,
+        outputTokens: 1,
+      },
+    });
     expect(cost.inputCost).toBeGreaterThan(0);
     expect(cost.outputCost).toBeGreaterThan(0);
     expect(cost.totalCost).toBeGreaterThan(0);
   });
 
   test("handles very large token counts", () => {
-    const cost = calculateCost({ provider: "openai", modelId: "gpt-4o", usage: {
-      inputTokens: 100_000_000,
-      outputTokens: 100_000_000,
-    }});
+    const cost = calculateCost({
+      provider: "openai",
+      modelId: "gpt-4o",
+      usage: {
+        inputTokens: 100_000_000,
+        outputTokens: 100_000_000,
+      },
+    });
     expect(cost.inputCost).toBe(250);
     expect(cost.outputCost).toBe(1000);
     expect(cost.totalCost).toBe(1250);
@@ -526,15 +554,17 @@ describe("PRICING", () => {
     for (const provider of Object.keys(PRICING)) {
       if (provider !== "openrouter") {
         // openrouter doesn't have default as it routes to other providers
-        expect(PRICING[provider]!.default).toBeDefined();
+        expect(PRICING[provider]?.default).toBeDefined();
       }
     }
   });
 
   test("all prices are non-negative", () => {
     for (const provider of Object.keys(PRICING)) {
-      for (const model of Object.keys(PRICING[provider]!)) {
-        const pricing = PRICING[provider]![model] as ModelPricing;
+      const providerPricing = PRICING[provider];
+      if (!providerPricing) continue;
+      for (const model of Object.keys(providerPricing)) {
+        const pricing = PRICING[provider]?.[model] as ModelPricing;
         expect(pricing.inputPrice).toBeGreaterThanOrEqual(0);
         expect(pricing.outputPrice).toBeGreaterThanOrEqual(0);
       }
@@ -609,47 +639,73 @@ describe("Cost Calculation Integration", () => {
   });
 
   test("Anthropic is more expensive than Groq for same token count", () => {
-    const anthropicCost = calculateCost({ provider: "anthropic", modelId: "claude-sonnet-4-5", usage: {
-      inputTokens: 10000,
-      outputTokens: 10000,
-    }});
-    const groqCost = calculateCost({ provider: "groq", modelId: "llama-3.3-70b-versatile", usage: {
-      inputTokens: 10000,
-      outputTokens: 10000,
-    }});
+    const anthropicCost = calculateCost({
+      provider: "anthropic",
+      modelId: "claude-sonnet-4-5",
+      usage: {
+        inputTokens: 10000,
+        outputTokens: 10000,
+      },
+    });
+    const groqCost = calculateCost({
+      provider: "groq",
+      modelId: "llama-3.3-70b-versatile",
+      usage: {
+        inputTokens: 10000,
+        outputTokens: 10000,
+      },
+    });
     expect(anthropicCost.totalCost).toBeGreaterThan(groqCost.totalCost);
   });
 
   test("Ollama is always free regardless of token count", () => {
-    const cost = calculateCost({ provider: "ollama", modelId: "any-model", usage: {
-      inputTokens: 10_000_000,
-      outputTokens: 10_000_000,
-    }});
+    const cost = calculateCost({
+      provider: "ollama",
+      modelId: "any-model",
+      usage: {
+        inputTokens: 10_000_000,
+        outputTokens: 10_000_000,
+      },
+    });
     expect(cost.totalCost).toBe(0);
   });
 
   test("output cost is typically higher than input cost per token", () => {
     // For most providers, output is more expensive than input
-    const cost = calculateCost({ provider: "openai", modelId: "gpt-4o", usage: {
-      inputTokens: 1000,
-      outputTokens: 1000,
-    }});
+    const cost = calculateCost({
+      provider: "openai",
+      modelId: "gpt-4o",
+      usage: {
+        inputTokens: 1000,
+        outputTokens: 1000,
+      },
+    });
     expect(cost.outputCost).toBeGreaterThan(cost.inputCost);
   });
 
   test("parseModelString + calculateCost integration", () => {
-    const { provider, modelId } = parseModelString("anthropic/claude-sonnet-4-5");
-    const cost = calculateCost({ provider, modelId, usage: {
-      inputTokens: 1000,
-      outputTokens: 500,
-    }});
+    const { provider, modelId } = parseModelString(
+      "anthropic/claude-sonnet-4-5",
+    );
+    const cost = calculateCost({
+      provider,
+      modelId,
+      usage: {
+        inputTokens: 1000,
+        outputTokens: 500,
+      },
+    });
     expect(cost.inputCost).toBeGreaterThan(0);
     expect(cost.outputCost).toBeGreaterThan(0);
     expect(cost.totalCost).toBe(cost.inputCost + cost.outputCost);
   });
 
   test("formatCost + calculateCost integration for zero usage", () => {
-    const cost = calculateCost({ provider: "openai", modelId: "gpt-4o", usage: {} });
+    const cost = calculateCost({
+      provider: "openai",
+      modelId: "gpt-4o",
+      usage: {},
+    });
     const formatted = formatCost(cost);
     expect(formatted).toBe("$0.0000 (0 tokens)");
   });

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, test } from "bun:test";
-import { mkdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { Config } from "../config.ts";
@@ -26,11 +25,16 @@ describe("buildPrompt", () => {
   });
 
   test("returns stdin when only stdin provided", () => {
-    expect(buildPrompt({ prompt: null, stdinContent: "hello world" })).toBe("hello world");
+    expect(buildPrompt({ prompt: null, stdinContent: "hello world" })).toBe(
+      "hello world",
+    );
   });
 
   test("combines arg prompt and stdin with double newline", () => {
-    const result = buildPrompt({ prompt: "review this code", stdinContent: "const x = 1;" });
+    const result = buildPrompt({
+      prompt: "review this code",
+      stdinContent: "const x = 1;",
+    });
     expect(result).toBe("review this code\n\nconst x = 1;");
   });
 
@@ -39,14 +43,20 @@ describe("buildPrompt", () => {
   });
 
   test("arg prompt comes first in combined output", () => {
-    const result = buildPrompt({ prompt: "summarize", stdinContent: "long document text" });
+    const result = buildPrompt({
+      prompt: "summarize",
+      stdinContent: "long document text",
+    });
     expect(result).not.toBeNull();
     expect(result?.startsWith("summarize")).toBe(true);
     expect(result?.endsWith("long document text")).toBe(true);
   });
 
   test("preserves multiline stdin content", () => {
-    const result = buildPrompt({ prompt: "review", stdinContent: "line1\nline2\nline3" });
+    const result = buildPrompt({
+      prompt: "review",
+      stdinContent: "line1\nline2\nline3",
+    });
     expect(result).toBe("review\n\nline1\nline2\nline3");
   });
 
@@ -65,22 +75,34 @@ describe("buildPrompt", () => {
   });
 
   test("returns file content only", () => {
-    const result = buildPrompt({ prompt: null, fileContent: "# f.txt\n```\nhello\n```" });
+    const result = buildPrompt({
+      prompt: null,
+      fileContent: "# f.txt\n```\nhello\n```",
+    });
     expect(result).toBe("# f.txt\n```\nhello\n```");
   });
 
   test("combines arg and file content without stdin", () => {
-    const result = buildPrompt({ prompt: "summarize", fileContent: "# f.txt\n```\ncontent\n```" });
+    const result = buildPrompt({
+      prompt: "summarize",
+      fileContent: "# f.txt\n```\ncontent\n```",
+    });
     expect(result).toBe("summarize\n\n# f.txt\n```\ncontent\n```");
   });
 
   test("combines file content and stdin without arg", () => {
-    const result = buildPrompt({ prompt: null, fileContent: "# f.txt\n```\ncontent\n```", stdinContent: "stdin" });
+    const result = buildPrompt({
+      prompt: null,
+      fileContent: "# f.txt\n```\ncontent\n```",
+      stdinContent: "stdin",
+    });
     expect(result).toBe("# f.txt\n```\ncontent\n```\n\nstdin");
   });
 
   test("returns empty string when all three are null", () => {
-    expect(buildPrompt({ prompt: null, fileContent: null, stdinContent: null })).toBe("");
+    expect(
+      buildPrompt({ prompt: null, fileContent: null, stdinContent: null }),
+    ).toBe("");
   });
 
   test("file content default param preserves two-arg behavior", () => {
@@ -134,8 +156,8 @@ describe("readImages", () => {
     await Bun.write(path, "fake png content");
     const result = await readImages([path]);
     expect(result).toHaveLength(1);
-    expect(result[0]!.url).toMatch(/^data:image\/png;base64,/);
-    expect(result[0]!.url).toContain("ZmFrZSBwbmcgY29udGVudA=="); // "fake png content" in base64
+    expect(result[0]?.url).toMatch(/^data:image\/png;base64,/);
+    expect(result[0]?.url).toContain("ZmFrZSBwbmcgY29udGVudA=="); // "fake png content" in base64
   });
 
   test("reads multiple images and returns data URLs", async () => {
@@ -145,8 +167,8 @@ describe("readImages", () => {
     await Bun.write(path2, "image two");
     const result = await readImages([path1, path2]);
     expect(result).toHaveLength(2);
-    expect(result[0]!.url).toMatch(/^data:image\/png;base64,/);
-    expect(result[1]!.url).toMatch(/^data:image\/jpeg;base64,/);
+    expect(result[0]?.url).toMatch(/^data:image\/png;base64,/);
+    expect(result[1]?.url).toMatch(/^data:image\/jpeg;base64,/);
   });
 
   test("throws on nonexistent image file", async () => {
@@ -170,7 +192,7 @@ describe("readImages", () => {
     const pngPath = join(tmpdir(), `test-${uid()}.png`);
     await Bun.write(pngPath, "\x89PNG\r\n\x1a\n");
     const result = await readImages([pngPath]);
-    expect(result[0]!.url).toMatch(/^data:image\/png;base64,/);
+    expect(result[0]?.url).toMatch(/^data:image\/png;base64,/);
   });
 
   test("handles empty image array", async () => {
@@ -187,6 +209,7 @@ describe("resolveOptions", () => {
     stream: true,
     markdown: false,
     cost: false,
+    cache: true,
   };
   const emptyConfig: Config = {};
 
@@ -442,7 +465,7 @@ describe("JsonOutputSchema", () => {
 // ── Session Sanitization ───────────────────────────────────────────────
 
 describe("session sanitization", () => {
-  const uid = () => `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  const _uid = () => `${Date.now()}-${Math.random().toString(36).slice(2)}`;
 
   test("allows valid alphanumeric session names", () => {
     expect(isValidSessionName("session123")).toBe(true);
@@ -509,7 +532,7 @@ describe("history loading", () => {
   });
 
   test("sanitizes session names when saving history", async () => {
-    const session = `test-sanitize-${uid()}`;
+    const _session = `test-sanitize-${uid()}`;
     const unsafeSession = "session with spaces/and slashes";
     const sanitized = sanitizeSessionName(unsafeSession);
 
@@ -727,7 +750,7 @@ describe("readImages edge cases", () => {
     await Bun.write(path, "fake jpeg data");
     const result = await readImages([path]);
     expect(result).toHaveLength(1);
-    expect(result[0]!.url).toMatch(/^data:image\/jpeg;base64,/);
+    expect(result[0]?.url).toMatch(/^data:image\/jpeg;base64,/);
   });
 });
 
@@ -900,7 +923,13 @@ describe("JsonOutputSchema additional", () => {
   });
 
   test("accepts all common finishReason values", () => {
-    for (const reason of ["stop", "length", "content-filter", "error", "other"]) {
+    for (const reason of [
+      "stop",
+      "length",
+      "content-filter",
+      "error",
+      "other",
+    ]) {
       const result = JsonOutputSchema.safeParse({
         text: "",
         model: "m",
@@ -1001,6 +1030,7 @@ describe("resolveOptions additional", () => {
     stream: true,
     markdown: false,
     cost: false,
+    cache: true,
   };
   const emptyConfig: Config = {};
 
@@ -1044,32 +1074,215 @@ describe("resolveOptions additional", () => {
   });
 });
 
+// ── resolveOptions provider-specific defaults ────────────────────────────
+
+describe("resolveOptions provider-specific defaults", () => {
+  const defaultOpts: CLIOptions = {
+    json: false,
+    stream: true,
+    markdown: false,
+    cost: false,
+    cache: true,
+  };
+  const _emptyConfig: Config = {};
+
+  test("provider-specific temperature overrides global config", () => {
+    const config: Config = {
+      model: "anthropic/claude-sonnet-4-5",
+      temperature: 0.7,
+      providers: {
+        anthropic: { temperature: 0.5 },
+      },
+    };
+    const result = resolveOptions(defaultOpts, config);
+    expect(result.temperature).toBe(0.5);
+  });
+
+  test("provider-specific system overrides global config", () => {
+    const config: Config = {
+      model: "anthropic/claude-sonnet-4-5",
+      system: "Global system.",
+      providers: {
+        anthropic: { system: "You are Claude." },
+      },
+    };
+    const result = resolveOptions(defaultOpts, config);
+    expect(result.system).toBe("You are Claude.");
+  });
+
+  test("provider-specific maxOutputTokens overrides global config", () => {
+    const config: Config = {
+      model: "anthropic/claude-sonnet-4-5",
+      maxOutputTokens: 1000,
+      providers: {
+        anthropic: { maxOutputTokens: 4096 },
+      },
+    };
+    const result = resolveOptions(defaultOpts, config);
+    expect(result.maxOutputTokens).toBe(4096);
+  });
+
+  test("CLI flags override provider-specific config", () => {
+    const config: Config = {
+      model: "anthropic/claude-sonnet-4-5",
+      temperature: 0.7,
+      providers: {
+        anthropic: { temperature: 0.5, system: "provider system" },
+      },
+    };
+    const opts: CLIOptions = {
+      ...defaultOpts,
+      temperature: 0.9,
+      system: "cli system",
+    };
+    const result = resolveOptions(opts, config);
+    expect(result.temperature).toBe(0.9);
+    expect(result.system).toBe("cli system");
+  });
+
+  test("missing provider section falls through to global config", () => {
+    const config: Config = {
+      model: "openai/gpt-4o",
+      temperature: 0.7,
+      system: "Global system.",
+      providers: {
+        anthropic: { temperature: 0.5 },
+      },
+    };
+    // openai model - no openai provider config, should use global
+    const result = resolveOptions(defaultOpts, config);
+    expect(result.temperature).toBe(0.7);
+    expect(result.system).toBe("Global system.");
+  });
+
+  test("no providers key at all falls through to global config", () => {
+    const config: Config = {
+      model: "anthropic/claude-sonnet-4-5",
+      temperature: 0.7,
+    };
+    const result = resolveOptions(defaultOpts, config);
+    expect(result.temperature).toBe(0.7);
+  });
+
+  test("provider overrides only specific fields, others fall through to global", () => {
+    const config: Config = {
+      model: "anthropic/claude-sonnet-4-5",
+      system: "Global system.",
+      temperature: 0.7,
+      maxOutputTokens: 1000,
+      providers: {
+        anthropic: { temperature: 0.5 },
+      },
+    };
+    const result = resolveOptions(defaultOpts, config);
+    expect(result.temperature).toBe(0.5); // from provider
+    expect(result.system).toBe("Global system."); // from global
+    expect(result.maxOutputTokens).toBe(1000); // from global
+  });
+
+  test("works with model specified via CLI flag", () => {
+    const config: Config = {
+      temperature: 0.7,
+      providers: {
+        google: { temperature: 0.3 },
+      },
+    };
+    const opts: CLIOptions = {
+      ...defaultOpts,
+      model: "google/gemini-2.5-flash",
+    };
+    const result = resolveOptions(opts, config);
+    expect(result.temperature).toBe(0.3);
+    expect(result.modelString).toBe("google/gemini-2.5-flash");
+  });
+
+  test("full resolution order: CLI > provider > global > defaults", () => {
+    const config: Config = {
+      model: "anthropic/claude-sonnet-4-5",
+      temperature: 0.7,
+      system: "Global system.",
+      maxOutputTokens: 500,
+      providers: {
+        anthropic: {
+          temperature: 0.5,
+          system: "Provider system.",
+          maxOutputTokens: 4096,
+        },
+      },
+    };
+    const opts: CLIOptions = {
+      ...defaultOpts,
+      temperature: 0.9, // CLI wins for temperature
+      // system not set - provider wins
+      // maxOutputTokens not set - provider wins
+    };
+    const result = resolveOptions(opts, config);
+    expect(result.temperature).toBe(0.9); // CLI flag
+    expect(result.system).toBe("Provider system."); // provider config
+    expect(result.maxOutputTokens).toBe(4096); // provider config
+  });
+
+  test("backward compatible with existing config (no providers key)", () => {
+    const config: Config = {
+      model: "openai/gpt-4o",
+      system: "Be concise.",
+      temperature: 0.7,
+      maxOutputTokens: 500,
+    };
+    const result = resolveOptions(defaultOpts, config);
+    expect(result.modelString).toBe("openai/gpt-4o");
+    expect(result.system).toBe("Be concise.");
+    expect(result.temperature).toBe(0.7);
+    expect(result.maxOutputTokens).toBe(500);
+  });
+});
+
 // ── buildPrompt edge cases ───────────────────────────────────────────────
 
 describe("buildPrompt edge cases", () => {
   test("empty string arg is treated as falsy", () => {
-    const result = buildPrompt({ prompt: "", fileContent: null, stdinContent: null });
+    const result = buildPrompt({
+      prompt: "",
+      fileContent: null,
+      stdinContent: null,
+    });
     expect(result).toBe("");
   });
 
   test("empty string stdin is treated as falsy", () => {
-    const result = buildPrompt({ prompt: null, fileContent: null, stdinContent: "" });
+    const result = buildPrompt({
+      prompt: null,
+      fileContent: null,
+      stdinContent: "",
+    });
     expect(result).toBe("");
   });
 
   test("whitespace-only arg is kept", () => {
-    const result = buildPrompt({ prompt: "  ", fileContent: null, stdinContent: null });
+    const result = buildPrompt({
+      prompt: "  ",
+      fileContent: null,
+      stdinContent: null,
+    });
     expect(result).toBe("  ");
   });
 
   test("handles very long prompt", () => {
     const longPrompt = "a".repeat(100000);
-    const result = buildPrompt({ prompt: longPrompt, fileContent: null, stdinContent: null });
+    const result = buildPrompt({
+      prompt: longPrompt,
+      fileContent: null,
+      stdinContent: null,
+    });
     expect(result.length).toBe(100000);
   });
 
   test("handles unicode content", () => {
-    const result = buildPrompt({ prompt: "Hello \u2603", fileContent: null, stdinContent: "\u00e9l\u00e8ve" });
+    const result = buildPrompt({
+      prompt: "Hello \u2603",
+      fileContent: null,
+      stdinContent: "\u00e9l\u00e8ve",
+    });
     expect(result).toContain("\u2603");
     expect(result).toContain("\u00e9l\u00e8ve");
   });

--- a/src/__tests__/tools.test.ts
+++ b/src/__tests__/tools.test.ts
@@ -24,7 +24,7 @@ describe("ToolsConfigSchema", () => {
     };
     const result = ToolsConfigSchema.parse(config);
     expect(result.tools).toHaveLength(1);
-    expect(result.tools![0]!.name).toBe("getWeather");
+    expect(result.tools?.[0]?.name).toBe("getWeather");
   });
 
   test("accepts empty tools array", () => {
@@ -67,7 +67,7 @@ describe("loadToolsConfig", () => {
 
     const result = await loadToolsConfig(configPath);
     expect(result).toHaveLength(1);
-    expect(result[0]!.name).toBe("getWeather");
+    expect(result[0]?.name).toBe("getWeather");
 
     rmSync(configPath);
   });

--- a/src/__tests__/update.test.ts
+++ b/src/__tests__/update.test.ts
@@ -1,11 +1,11 @@
-import { test, expect, describe, beforeEach, afterEach } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdir, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { mkdir, rm } from "node:fs/promises";
 import {
+  checkForUpdates,
   compareVersions,
   shouldCheckForUpdates,
-  checkForUpdates,
 } from "../update.ts";
 
 describe("compareVersions", () => {
@@ -72,7 +72,7 @@ describe("checkForUpdates", () => {
     // Use a path that will cause the fetch to fail (invalid registry)
     // by mocking fetch to throw
     const originalFetch = globalThis.fetch;
-    globalThis.fetch = () => {
+    (globalThis as Record<string, unknown>).fetch = () => {
       throw new Error("Network error");
     };
 
@@ -89,7 +89,7 @@ describe("checkForUpdates", () => {
     const originalFetch = globalThis.fetch;
     const pkg = await import("../../package.json");
 
-    globalThis.fetch = async () =>
+    (globalThis as Record<string, unknown>).fetch = async () =>
       new Response(JSON.stringify({ version: pkg.default.version }), {
         status: 200,
       });
@@ -106,7 +106,7 @@ describe("checkForUpdates", () => {
   test("returns message when update is available", async () => {
     const originalFetch = globalThis.fetch;
 
-    globalThis.fetch = async () =>
+    (globalThis as Record<string, unknown>).fetch = async () =>
       new Response(JSON.stringify({ version: "99.99.99" }), {
         status: 200,
       });
@@ -126,7 +126,7 @@ describe("checkForUpdates", () => {
   test("returns null when registry returns non-ok status", async () => {
     const originalFetch = globalThis.fetch;
 
-    globalThis.fetch = async () =>
+    (globalThis as Record<string, unknown>).fetch = async () =>
       new Response("Not Found", { status: 404 });
 
     try {

--- a/src/cost.ts
+++ b/src/cost.ts
@@ -2,7 +2,10 @@
 const TOKENS_PER_UNIT = 1_000_000;
 
 /** Default pricing for unknown providers/models */
-const ZERO_PRICING: ModelPricing = Object.freeze({ inputPrice: 0, outputPrice: 0 });
+const ZERO_PRICING: ModelPricing = Object.freeze({
+  inputPrice: 0,
+  outputPrice: 0,
+});
 
 /** Cost decimal precision for formatting */
 const COST_DECIMAL_PLACES = 4;

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -181,9 +181,15 @@ export function resolveModel(modelString: string) {
   const missingVars = envVars.filter((v) => !process.env[v]);
 
   if (missingVars.length > 0) {
-    const exportCmds = missingVars.map((v) => `export ${v}=<your-key>`).join("\n  ");
-    const usesApiKey = missingVars.some((v) => v.endsWith("_API_KEY") || v.endsWith("_TOKEN"));
-    const apiKeysHint = usesApiKey ? ` Or add the key(s) to ~/.ai-pipe/apiKeys.json.` : "";
+    const exportCmds = missingVars
+      .map((v) => `export ${v}=<your-key>`)
+      .join("\n  ");
+    const usesApiKey = missingVars.some(
+      (v) => v.endsWith("_API_KEY") || v.endsWith("_TOKEN"),
+    );
+    const apiKeysHint = usesApiKey
+      ? ` Or add the key(s) to ~/.ai-pipe/apiKeys.json.`
+      : "";
     console.error(
       `Error: Missing required environment variable(s): ${missingVars.join(", ")}.\nSet them with:\n  ${exportCmds}${apiKeysHint}`,
     );

--- a/src/update.ts
+++ b/src/update.ts
@@ -1,5 +1,5 @@
 import { homedir } from "node:os";
-import { join, dirname } from "node:path";
+import { dirname, join } from "node:path";
 import pkg from "../package.json";
 import { APP } from "./constants.ts";
 


### PR DESCRIPTION
## Summary
- Per-provider overrides for temperature, maxOutputTokens, system prompt, model in config.json
- Resolution order: CLI flags > provider config > global config > defaults
- Fully backward compatible with existing configs
- 29 new tests for config and resolution behavior

## Test plan
- [ ] Config without `providers` key works unchanged
- [ ] Provider-specific temperature overrides global
- [ ] CLI flags override provider-specific config