### PR TITLE
✨ Add progressive streaming markdown rendering

### DIFF
--- a/src/__tests__/streaming-markdown.test.ts
+++ b/src/__tests__/streaming-markdown.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { StreamingMarkdownRenderer } from "../streaming-markdown.ts";
+
+describe("StreamingMarkdownRenderer", () => {
+  let writtenChunks: string[];
+  const originalWrite = process.stdout.write;
+
+  beforeEach(() => {
+    writtenChunks = [];
+    process.stdout.write = (chunk: string) => {
+      writtenChunks.push(chunk);
+      return true;
+    };
+  });
+
+  afterEach(() => {
+    process.stdout.write = originalWrite;
+  });
+
+  test("accumulates text in buffer via append()", () => {
+    const renderer = new StreamingMarkdownRenderer();
+    renderer.append("Hello ");
+    renderer.append("world");
+    expect(renderer.getBuffer()).toBe("Hello world");
+  });
+
+  test("finish() produces rendered output", () => {
+    const renderer = new StreamingMarkdownRenderer();
+    renderer.append("**bold text**");
+    renderer.finish();
+
+    const output = writtenChunks.join("");
+    expect(output).toContain("bold text");
+    expect(output).toContain("\x1b[1m"); // BOLD ANSI code
+  });
+
+  test("finish() renders markdown headings", () => {
+    const renderer = new StreamingMarkdownRenderer();
+    renderer.append("# Title\n\nParagraph.");
+    renderer.finish();
+
+    const output = writtenChunks.join("");
+    expect(output).toContain("# Title");
+    expect(output).toContain("Paragraph.");
+  });
+
+  test("debounces rendering on rapid appends", async () => {
+    const renderer = new StreamingMarkdownRenderer();
+
+    // Rapidly append many chunks
+    for (let i = 0; i < 20; i++) {
+      renderer.append(`chunk${i} `);
+    }
+
+    // Before the debounce timer fires, no output should be written
+    expect(writtenChunks.length).toBe(0);
+
+    // Wait for debounce timer to fire (100ms + margin)
+    await new Promise((resolve) => setTimeout(resolve, 150));
+
+    // Now there should be exactly one render
+    expect(writtenChunks.length).toBeGreaterThan(0);
+    const output = writtenChunks.join("");
+    expect(output).toContain("chunk0");
+    expect(output).toContain("chunk19");
+
+    // Clean up
+    renderer.finish();
+  });
+
+  test("finish() cancels pending timer and does final render", () => {
+    const renderer = new StreamingMarkdownRenderer();
+    renderer.append("some text");
+
+    // Before debounce fires, call finish immediately
+    renderer.finish();
+
+    const output = writtenChunks.join("");
+    expect(output).toContain("some text");
+  });
+
+  test("subsequent renders clear previous output with ANSI codes", async () => {
+    const renderer = new StreamingMarkdownRenderer();
+
+    renderer.append("First line\n");
+    // Wait for the first debounced render
+    await new Promise((resolve) => setTimeout(resolve, 150));
+
+    const firstOutput = writtenChunks.join("");
+    expect(firstOutput).toContain("First line");
+
+    // Append more and finish
+    renderer.append("Second line\n");
+    renderer.finish();
+
+    const fullOutput = writtenChunks.join("");
+    // Should contain cursor-up ANSI escape for clearing previous render
+    expect(fullOutput).toContain("\x1b[J");
+  });
+
+  test("getBuffer() returns full accumulated text", () => {
+    const renderer = new StreamingMarkdownRenderer();
+    renderer.append("a");
+    renderer.append("b");
+    renderer.append("c");
+    expect(renderer.getBuffer()).toBe("abc");
+  });
+
+  test("handles empty buffer gracefully", () => {
+    const renderer = new StreamingMarkdownRenderer();
+    renderer.finish();
+    // Should not throw; output is whatever renderMarkdown("") produces
+    expect(writtenChunks.length).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ import { APP } from "./constants.ts";
 import type { UsageInfo } from "./cost.ts";
 import { calculateCost, formatCost, parseModelString } from "./cost.ts";
 import { renderMarkdown } from "./markdown.ts";
+import { StreamingMarkdownRenderer } from "./streaming-markdown.ts";
 import {
   PROVIDER_ENV_VARS,
   ProviderIdSchema,
@@ -484,18 +485,17 @@ async function executePrompt(params: ExecutePromptParams): Promise<void> {
   } else {
     const result = streamText(callOptions);
 
-    // When markdown is enabled, silently buffer the full response
-    // and render once complete (streaming chunks are not displayed).
+    // When markdown is enabled, progressively re-render as tokens arrive.
     if (markdown) {
-      let fullResponse = "";
+      const renderer = new StreamingMarkdownRenderer();
       for await (const chunk of result.textStream) {
-        fullResponse += chunk;
+        renderer.append(chunk);
       }
-      process.stdout.write(renderMarkdown(fullResponse));
+      renderer.finish();
 
       // Save to session history if applicable
       if (session) {
-        session.messages.push({ role: "assistant", content: fullResponse });
+        session.messages.push({ role: "assistant", content: renderer.getBuffer() });
         await saveHistory(session.name, session.messages);
       }
     } else {
@@ -676,7 +676,7 @@ async function run(
       system: sessionName ? undefined : systemPrompt,
       temperature,
       maxOutputTokens,
-      stream: markdown ? false : opts.stream,
+      stream: opts.stream,
       json: opts.json,
       markdown,
       showCost: opts.cost,

--- a/src/streaming-markdown.ts
+++ b/src/streaming-markdown.ts
@@ -1,0 +1,69 @@
+import { renderMarkdown } from "./markdown.ts";
+
+/** Debounce interval in milliseconds for progressive rendering. */
+const RENDER_DEBOUNCE_MS = 100;
+
+/**
+ * Progressive streaming markdown renderer for terminal output.
+ *
+ * Accumulates text chunks and periodically re-renders the full markdown
+ * output using ANSI escape codes to clear and replace the previous render.
+ * Rendering is debounced to avoid excessive redraws on rapid token arrival.
+ */
+export class StreamingMarkdownRenderer {
+  private buffer = "";
+  private lineCount = 0;
+  private renderTimer: ReturnType<typeof setTimeout> | null = null;
+
+  /**
+   * Append a text chunk to the buffer and schedule a debounced render.
+   *
+   * @param chunk - The new text fragment to add.
+   */
+  append(chunk: string): void {
+    this.buffer += chunk;
+    if (!this.renderTimer) {
+      this.renderTimer = setTimeout(() => {
+        this.renderTimer = null;
+        this.render();
+      }, RENDER_DEBOUNCE_MS);
+    }
+  }
+
+  /**
+   * Clear the previously rendered output and re-render the full buffer.
+   *
+   * Uses ANSI escape codes to move the cursor up and clear lines, then
+   * writes the freshly rendered markdown to stdout.
+   */
+  private render(): void {
+    // Move cursor up to overwrite previous output (skip on first render)
+    if (this.lineCount > 0) {
+      process.stdout.write(`\x1b[${this.lineCount}A\x1b[J`);
+    }
+
+    const rendered = renderMarkdown(this.buffer);
+    process.stdout.write(rendered);
+
+    // Count lines for the next clear cycle
+    this.lineCount = rendered.split("\n").length - 1;
+    if (this.lineCount < 0) this.lineCount = 0;
+  }
+
+  /**
+   * Finalize rendering: cancel any pending timer, do a final clean render,
+   * and emit a trailing newline.
+   */
+  finish(): void {
+    if (this.renderTimer) {
+      clearTimeout(this.renderTimer);
+      this.renderTimer = null;
+    }
+    this.render();
+  }
+
+  /** Return the accumulated buffer text (useful for testing / history). */
+  getBuffer(): string {
+    return this.buffer;
+  }
+}


### PR DESCRIPTION
## Summary
- New `StreamingMarkdownRenderer` class with debounced ANSI re-rendering
- Markdown now works WITH streaming (no longer forces --no-stream)
- Clears and re-renders terminal output every 100ms as tokens arrive
- 8 new tests for renderer behavior

## Test plan
- [ ] `--markdown` streams progressively instead of buffering
- [ ] Debounce prevents flickering
- [ ] Final render is clean