### PR TITLE
✨ Add interactive chat mode with --chat flag

### DIFF
--- a/src/__tests__/chat.test.ts
+++ b/src/__tests__/chat.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test } from "bun:test";
+import { join } from "node:path";
+
+import { CLEAR_COMMAND, EXIT_COMMANDS, startChat } from "../chat.ts";
+
+// ── Module exports ──────────────────────────────────────────────────────
+
+describe("chat module exports", () => {
+  test("exports startChat function", () => {
+    expect(typeof startChat).toBe("function");
+  });
+
+  test("exports EXIT_COMMANDS set", () => {
+    expect(EXIT_COMMANDS).toBeInstanceOf(Set);
+    expect(EXIT_COMMANDS.has("exit")).toBe(true);
+    expect(EXIT_COMMANDS.has("quit")).toBe(true);
+    expect(EXIT_COMMANDS.has("/bye")).toBe(true);
+  });
+
+  test("exports CLEAR_COMMAND constant", () => {
+    expect(CLEAR_COMMAND).toBe("/clear");
+  });
+});
+
+// ── Exit commands ───────────────────────────────────────────────────────
+
+describe("exit commands", () => {
+  test("recognizes exit", () => {
+    expect(EXIT_COMMANDS.has("exit")).toBe(true);
+  });
+
+  test("recognizes quit", () => {
+    expect(EXIT_COMMANDS.has("quit")).toBe(true);
+  });
+
+  test("recognizes /bye", () => {
+    expect(EXIT_COMMANDS.has("/bye")).toBe(true);
+  });
+
+  test("does not recognize random strings", () => {
+    expect(EXIT_COMMANDS.has("hello")).toBe(false);
+    expect(EXIT_COMMANDS.has("stop")).toBe(false);
+    expect(EXIT_COMMANDS.has("/exit")).toBe(false);
+  });
+});
+
+// ── Clear command ───────────────────────────────────────────────────────
+
+describe("clear command", () => {
+  test("is /clear", () => {
+    expect(CLEAR_COMMAND).toBe("/clear");
+  });
+});
+
+// ── CLI integration (--chat flag) ───────────────────────────────────────
+
+describe("CLI: --chat flag", () => {
+  const CLI = join(import.meta.dir, "..", "index.ts");
+
+  test("--chat appears in help output", async () => {
+    const proc = Bun.spawn(["bun", CLI, "--help"], {
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const stdout = await new Response(proc.stdout).text();
+    await proc.exited;
+    expect(stdout).toContain("--chat");
+    expect(stdout).toContain("interactive chat mode");
+  });
+
+  test("--chat without API key errors with missing env var", async () => {
+    const proc = Bun.spawn(["bun", CLI, "--chat"], {
+      stdin: new Blob(["exit\n"]),
+      stdout: "pipe",
+      stderr: "pipe",
+      env: {
+        ...process.env,
+        OPENAI_API_KEY: "",
+        ANTHROPIC_API_KEY: "",
+      },
+    });
+    const stderr = await new Response(proc.stderr).text();
+    const exitCode = await proc.exited;
+    expect(stderr).toContain("Missing required environment variable");
+    expect(exitCode).toBe(1);
+  });
+});
+
+// ── ChatOptions interface ───────────────────────────────────────────────
+
+describe("ChatOptions validation", () => {
+  test("startChat rejects when called with invalid model", async () => {
+    // startChat expects a LanguageModel; passing null should throw
+    try {
+      await startChat({
+        // @ts-expect-error testing invalid model input
+        model: null,
+        modelString: "test/model",
+        markdown: false,
+        showCost: false,
+      });
+      // Should not reach here
+      expect(true).toBe(false);
+    } catch {
+      // Expected to throw
+      expect(true).toBe(true);
+    }
+  });
+});

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -209,6 +209,7 @@ describe("resolveOptions", () => {
     stream: true,
     markdown: false,
     cost: false,
+    chat: false,
     cache: true,
   };
   const emptyConfig: Config = {};
@@ -1030,6 +1031,7 @@ describe("resolveOptions additional", () => {
     stream: true,
     markdown: false,
     cost: false,
+    chat: false,
     cache: true,
   };
   const emptyConfig: Config = {};
@@ -1082,6 +1084,7 @@ describe("resolveOptions provider-specific defaults", () => {
     stream: true,
     markdown: false,
     cost: false,
+    chat: false,
     cache: true,
   };
   const _emptyConfig: Config = {};

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -1,0 +1,189 @@
+import * as readline from "node:readline";
+import { type LanguageModel, type ModelMessage, streamText } from "ai";
+
+import type { UsageInfo } from "./cost.ts";
+import { calculateCost, formatCost, parseModelString } from "./cost.ts";
+import { renderMarkdown } from "./markdown.ts";
+
+/** Commands that exit the chat session. */
+const EXIT_COMMANDS = new Set(["exit", "quit", "/bye"]);
+
+/** Commands that clear conversation history. */
+const CLEAR_COMMAND = "/clear";
+
+/** Options accepted by startChat. */
+export interface ChatOptions {
+  model: LanguageModel;
+  modelString: string;
+  system?: string;
+  temperature?: number;
+  maxOutputTokens?: number;
+  markdown: boolean;
+  showCost: boolean;
+}
+
+/** The accumulated cost totals across the chat session. */
+interface RunningCost {
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  totalCost: number;
+}
+
+/**
+ * Start an interactive chat REPL.
+ *
+ * Maintains a conversation history in memory and streams responses by default.
+ * Supports `/clear` to reset history, and `exit`/`quit`/`/bye`/Ctrl-C/Ctrl-D
+ * to exit cleanly.
+ *
+ * @param options - Resolved CLI options including model, system prompt, and display flags.
+ */
+export async function startChat(options: ChatOptions): Promise<void> {
+  const {
+    model,
+    modelString,
+    system,
+    temperature,
+    maxOutputTokens,
+    markdown,
+    showCost,
+  } = options;
+
+  const messages: ModelMessage[] = [];
+  if (system) {
+    messages.push({ role: "system", content: system });
+  }
+
+  const runningCost: RunningCost = {
+    totalInputTokens: 0,
+    totalOutputTokens: 0,
+    totalCost: 0,
+  };
+
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stderr,
+    prompt: "> ",
+    terminal: true,
+  });
+
+  console.error(`Chat mode started. Model: ${modelString}`);
+  console.error(`Type "exit", "quit", "/bye", or press Ctrl+C/Ctrl+D to exit.`);
+  console.error(`Type "/clear" to reset conversation history.\n`);
+
+  rl.prompt();
+
+  // Wrap the REPL loop in a promise so startChat awaits until exit
+  return new Promise<void>((resolve) => {
+    rl.on("line", async (input: string) => {
+      const trimmed = input.trim();
+
+      // Skip empty lines
+      if (!trimmed) {
+        rl.prompt();
+        return;
+      }
+
+      // Handle exit commands
+      if (EXIT_COMMANDS.has(trimmed.toLowerCase())) {
+        console.error("\nGoodbye!");
+        rl.close();
+        return;
+      }
+
+      // Handle /clear command
+      if (trimmed.toLowerCase() === CLEAR_COMMAND) {
+        // Keep only the system message if present
+        messages.length = 0;
+        if (system) {
+          messages.push({ role: "system", content: system });
+        }
+        runningCost.totalInputTokens = 0;
+        runningCost.totalOutputTokens = 0;
+        runningCost.totalCost = 0;
+        console.error("Conversation history cleared.\n");
+        rl.prompt();
+        return;
+      }
+
+      // Add user message to history
+      messages.push({ role: "user", content: trimmed });
+
+      try {
+        const result = streamText({
+          model,
+          messages,
+          temperature,
+          maxOutputTokens,
+        });
+
+        // Stream the response
+        let fullResponse = "";
+        if (markdown) {
+          // Buffer the full response for markdown rendering
+          for await (const chunk of result.textStream) {
+            fullResponse += chunk;
+          }
+          process.stdout.write(renderMarkdown(fullResponse));
+        } else {
+          for await (const chunk of result.textStream) {
+            process.stdout.write(chunk);
+            fullResponse += chunk;
+          }
+          process.stdout.write("\n");
+        }
+
+        // Add assistant response to history
+        messages.push({ role: "assistant", content: fullResponse });
+
+        // Display cost if enabled
+        if (showCost) {
+          const usage: UsageInfo | undefined = await result.usage;
+          if (usage) {
+            const { provider, modelId } = parseModelString(modelString);
+            const costInfo = calculateCost({ provider, modelId, usage });
+
+            runningCost.totalInputTokens += costInfo.inputTokens;
+            runningCost.totalOutputTokens += costInfo.outputTokens;
+            runningCost.totalCost += costInfo.totalCost;
+
+            const turnCost = formatCost(costInfo);
+            console.error(`\nTurn cost: ${turnCost}`);
+            console.error(
+              `Session total: $${runningCost.totalCost.toFixed(4)} (${runningCost.totalInputTokens.toLocaleString()} in, ${runningCost.totalOutputTokens.toLocaleString()} out)`,
+            );
+          }
+        }
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err);
+        console.error(`\nError: ${message}`);
+        // Remove the failed user message so it doesn't pollute history
+        messages.pop();
+      }
+
+      process.stdout.write("\n");
+      rl.prompt();
+    });
+
+    rl.on("close", () => {
+      if (showCost && runningCost.totalCost > 0) {
+        console.error(
+          `\nSession total cost: $${runningCost.totalCost.toFixed(4)} (${runningCost.totalInputTokens.toLocaleString()} in, ${runningCost.totalOutputTokens.toLocaleString()} out)`,
+        );
+      }
+      resolve();
+    });
+
+    // Handle SIGINT (Ctrl+C) gracefully
+    rl.on("SIGINT", () => {
+      console.error("\nGoodbye!");
+      rl.close();
+    });
+  });
+}
+
+/**
+ * Get the current messages array from a chat session.
+ * Exported for testing purposes.
+ */
+export { EXIT_COMMANDS, CLEAR_COMMAND };

--- a/src/completions.ts
+++ b/src/completions.ts
@@ -49,7 +49,7 @@ _${funcName}_completions() {
   COMPREPLY=()
   cur="\${COMP_WORDS[COMP_CWORD]}"
   prev="\${COMP_WORDS[COMP_CWORD-1]}"
-  opts="--model -m --system -s --role -r --roles --file -f --image -i --json -j --no-stream --no-cache --temperature -t --max-output-tokens --config -c --cost --markdown --session -C --providers --completions --no-update-check --version -V --help -h"
+  opts="--model -m --system -s --role -r --roles --file -f --image -i --json -j --no-stream --no-cache --temperature -t --max-output-tokens --config -c --cost --markdown --chat --session -C --providers --completions --no-update-check --version -V --help -h"
   providers="${providers}"
 
   case "\${prev}" in
@@ -110,6 +110,7 @@ _${funcName}() {
     '(-c --config)'{-c,--config}'[Path to config directory]:dir:_directories' \\
     '--cost[Show token usage and cost after response]' \\
     '--markdown[Render response as formatted markdown]' \\
+    '--chat[Start interactive chat mode]' \\
     '(-C --session)'{-C,--session}'[Session name for conversation continuity]:session:' \\
     '--providers[List supported providers]' \\
     '--completions[Generate shell completions]:shell:(${shells})' \\
@@ -146,6 +147,7 @@ complete -c ${name} -l max-output-tokens -d 'Maximum tokens to generate' -x
 complete -c ${name} -s c -l config -d 'Path to config directory' -x -a '(__fish_complete_directories)'
 complete -c ${name} -l cost -d 'Show token usage and cost after response'
 complete -c ${name} -l markdown -d 'Render response as formatted markdown'
+complete -c ${name} -l chat -d 'Start interactive chat mode'
 complete -c ${name} -s C -l session -d 'Session name for conversation continuity' -x
 complete -c ${name} -l providers -d 'List supported providers'
 complete -c ${name} -l completions -d 'Generate shell completions' -x -a '${shells}'
@@ -167,6 +169,7 @@ complete -c ai -l max-output-tokens -d 'Maximum tokens to generate' -x
 complete -c ai -s c -l config -d 'Path to config directory' -x -a '(__fish_complete_directories)'
 complete -c ai -l cost -d 'Show token usage and cost after response'
 complete -c ai -l markdown -d 'Render response as formatted markdown'
+complete -c ai -l chat -d 'Start interactive chat mode'
 complete -c ai -s C -l session -d 'Session name for conversation continuity' -x
 complete -c ai -l providers -d 'List supported providers'
 complete -c ai -l completions -d 'Generate shell completions' -x -a '${shells}'


### PR DESCRIPTION
## Summary
- New `--chat` flag for interactive REPL mode
- Conversation history maintained in memory across turns
- Streaming responses by default
- `/clear` to reset history, `exit`/`quit`/`/bye`/Ctrl+C/Ctrl+D to exit
- Running cost total when `--cost` is enabled
- Markdown rendering support in chat mode
- 11 new tests

## Test plan
- [ ] `ai-pipe --chat` enters interactive mode
- [ ] Multi-turn conversation maintains context
- [ ] `/clear` resets history
- [ ] Exit commands work