### PR TITLE
Add prompt templates with variable substitution

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ A powerful CLI for calling LLMs from the terminal. Text in, text out. Built on t
 - 💾 **Response Caching** — skip duplicate API calls with built-in cache
 - 🔔 **Update Notifications** — automatic new version alerts
 - 🔧 **Tool Use** — function calling via `--tools`
+- 📄 **Prompt Templates** — reusable prompt snippets with `--template`
 
 ## 📦 Installation
 
@@ -261,6 +262,29 @@ eval "$(ai-pipe --completions zsh)"
 ai-pipe --completions fish > ~/.config/fish/completions/ai-pipe.fish
 ```
 
+### Prompt Templates
+
+Save reusable prompt snippets in `~/.ai-pipe/templates/` as `.md` files. Templates can contain `{{input}}` placeholders that get replaced with your prompt text.
+
+```bash
+# Create a template
+mkdir -p ~/.ai-pipe/templates
+echo "Review the following code for bugs, security issues, and best practices:
+
+{{input}}
+
+Provide specific, actionable feedback." > ~/.ai-pipe/templates/review.md
+
+# Use a template
+ai-pipe -T review -f main.go
+
+# Use a template with piped input
+cat src/app.ts | ai-pipe -T review
+
+# List available templates
+ai-pipe --templates
+```
+
 ## 📊 JSON Output
 
 Use `--json` to get structured output:
@@ -310,6 +334,8 @@ Options:
   -i, --image <path>           Attach image for vision models (repeatable)
   -r, --role <name>            Use a saved system prompt from ~/.ai-pipe/roles/
   --roles                      List available roles
+  -T, --template <name>        Use a prompt template from ~/.ai-pipe/templates/
+  --templates                  List available templates
   -C, --session [name]         Continue conversation or start named session
   --cost                       Show estimated token costs
   --markdown                   Render formatted markdown output
@@ -383,7 +409,7 @@ The release workflow handles `bun publish`, binary builds, and GitHub release.
 - [x] **Streaming markdown** — progressive markdown rendering during streaming
 - [x] **Config commands** — `ai-pipe init` wizard, `config set/show/reset/path`
 - [x] **citty migration** — replaced Commander.js with citty (UnJS)
-- [ ] **Prompt templates** — reusable prompt snippets in `~/.ai-pipe/templates/`
+- [x] **Prompt templates** — reusable prompt snippets in `~/.ai-pipe/templates/`
 - [ ] **Output formats** — CSV, YAML, TOML structured output modes
 - [ ] **Piped chain mode** — chain multiple LLM calls with `|` syntax
 - [ ] **Session export/import** — share conversations as JSON/Markdown

--- a/src/__tests__/templates.test.ts
+++ b/src/__tests__/templates.test.ts
@@ -1,0 +1,253 @@
+import { describe, expect, test } from "bun:test";
+import { mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { applyTemplate, listTemplates, loadTemplate } from "../templates.ts";
+
+const tmpDir = tmpdir();
+const uid = () => `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+
+function makeTmpDir(): string {
+  const dir = join(tmpDir, `ai-tpl-${uid()}`);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+// ── loadTemplate ────────────────────────────────────────────────────────
+
+describe("loadTemplate", () => {
+  test("returns template content when file exists", async () => {
+    const tplDir = join(tmpDir, `ai-tpl-load-${uid()}`);
+    const templateName = `review-${uid()}`;
+    const content =
+      "Review the following code:\n\n{{input}}\n\nProvide feedback.";
+    mkdirSync(join(tplDir, "templates"), { recursive: true });
+    await Bun.write(join(tplDir, "templates", `${templateName}.md`), content);
+
+    const result = await loadTemplate(templateName, tplDir);
+    expect(result).toBe(content);
+
+    rmSync(tplDir, { recursive: true });
+  });
+
+  test("returns null when template does not exist", async () => {
+    const tplDir = makeTmpDir();
+    const result = await loadTemplate("nonexistent-template-xyz", tplDir);
+    expect(result).toBeNull();
+
+    rmSync(tplDir, { recursive: true });
+  });
+
+  test("strips .md extension from template name", async () => {
+    const tplDir = join(tmpDir, `ai-tpl-ext-${uid()}`);
+    const templateName = "summarize";
+    mkdirSync(join(tplDir, "templates"), { recursive: true });
+    await Bun.write(
+      join(tplDir, "templates", `${templateName}.md`),
+      "Summarize: {{input}}",
+    );
+
+    // Pass templateName with .md extension - should still work
+    const result = await loadTemplate(`${templateName}.md`, tplDir);
+    expect(result).toBe("Summarize: {{input}}");
+
+    rmSync(tplDir, { recursive: true });
+  });
+
+  test("prevents path traversal with ../", async () => {
+    const tplDir = makeTmpDir();
+    const result = await loadTemplate("../etc/passwd", tplDir);
+    expect(result).toBeNull();
+
+    rmSync(tplDir, { recursive: true });
+  });
+
+  test("prevents path traversal with absolute path", async () => {
+    const tplDir = makeTmpDir();
+    const result = await loadTemplate("/etc/passwd", tplDir);
+    expect(result).toBeNull();
+
+    rmSync(tplDir, { recursive: true });
+  });
+
+  test("returns null for empty template name", async () => {
+    const tplDir = makeTmpDir();
+    mkdirSync(join(tplDir, "templates"), { recursive: true });
+    const result = await loadTemplate("", tplDir);
+    expect(result).toBeNull();
+
+    rmSync(tplDir, { recursive: true });
+  });
+
+  test("handles template with .MD extension (case insensitive strip)", async () => {
+    const tplDir = join(tmpDir, `ai-tpl-case-${uid()}`);
+    mkdirSync(join(tplDir, "templates"), { recursive: true });
+    const templateName = "CaseTest";
+    await Bun.write(
+      join(tplDir, "templates", `${templateName}.md`),
+      "Case test content",
+    );
+    // Pass with uppercase .MD extension
+    const result = await loadTemplate(`${templateName}.MD`, tplDir);
+    expect(result).toBe("Case test content");
+
+    rmSync(tplDir, { recursive: true });
+  });
+
+  test("handles template file with unicode content", async () => {
+    const tplDir = join(tmpDir, `ai-tpl-unicode-${uid()}`);
+    mkdirSync(join(tplDir, "templates"), { recursive: true });
+    const templateName = `unicode-${uid()}`;
+    const content = "Translate this: {{input}} \u2603 \u00e9l\u00e8ve.";
+    await Bun.write(join(tplDir, "templates", `${templateName}.md`), content);
+    const result = await loadTemplate(templateName, tplDir);
+    expect(result).toBe(content);
+
+    rmSync(tplDir, { recursive: true });
+  });
+});
+
+// ── listTemplates ───────────────────────────────────────────────────────
+
+describe("listTemplates", () => {
+  test("returns sorted template names", async () => {
+    const tplDir = join(tmpDir, `ai-tpl-list-${uid()}`);
+    const nameA = `aaa-template-${uid()}`;
+    const nameZ = `zzz-template-${uid()}`;
+    mkdirSync(join(tplDir, "templates"), { recursive: true });
+
+    await Bun.write(join(tplDir, "templates", `${nameZ}.md`), "Z template");
+    await Bun.write(join(tplDir, "templates", `${nameA}.md`), "A template");
+
+    const result = await listTemplates(tplDir);
+    const aIndex = result.indexOf(nameA);
+    const zIndex = result.indexOf(nameZ);
+    expect(aIndex).toBeLessThan(zIndex);
+
+    rmSync(tplDir, { recursive: true });
+  });
+
+  test("returns empty array when templates directory does not exist", async () => {
+    const tplDir = join(tmpDir, `ai-no-templates-${uid()}`);
+    mkdirSync(tplDir, { recursive: true });
+
+    const result = await listTemplates(tplDir);
+    expect(Array.isArray(result)).toBe(true);
+    expect(result).toEqual([]);
+
+    rmSync(tplDir, { recursive: true });
+  });
+
+  test("returns empty array for nonexistent config directory", async () => {
+    const result = await listTemplates("/nonexistent/path/to/config");
+    expect(result).toEqual([]);
+  });
+
+  test("lists only .md files and ignores other extensions", async () => {
+    const tplDir = join(tmpDir, `ai-tpl-filter-${uid()}`);
+    const name1 = `template1-${uid()}`;
+    const name2 = `template2-${uid()}`;
+    const nameTxt = `ignored-${uid()}`;
+    mkdirSync(join(tplDir, "templates"), { recursive: true });
+
+    await Bun.write(join(tplDir, "templates", `${name1}.md`), "Template 1");
+    await Bun.write(join(tplDir, "templates", `${name2}.md`), "Template 2");
+    await Bun.write(
+      join(tplDir, "templates", `${nameTxt}.txt`),
+      "This should be ignored",
+    );
+
+    const result = await listTemplates(tplDir);
+    expect(result).toContain(name1);
+    expect(result).toContain(name2);
+    expect(result).not.toContain(nameTxt);
+
+    rmSync(tplDir, { recursive: true });
+  });
+
+  test("returns unique template names (no duplicates)", async () => {
+    const tplDir = join(tmpDir, `ai-tpl-unique-${uid()}`);
+    mkdirSync(join(tplDir, "templates"), { recursive: true });
+
+    const templateName = `unique-tpl-${uid()}`;
+    await Bun.write(join(tplDir, "templates", `${templateName}.md`), "Content");
+
+    const result = await listTemplates(tplDir);
+    const count = result.filter((t) => t === templateName).length;
+    expect(count).toBe(1);
+
+    rmSync(tplDir, { recursive: true });
+  });
+
+  test("handles empty templates directory (exists but no files)", async () => {
+    const tplDir = join(tmpDir, `ai-tpl-empty-${uid()}`);
+    mkdirSync(join(tplDir, "templates"), { recursive: true });
+
+    const result = await listTemplates(tplDir);
+    expect(result).toEqual([]);
+
+    rmSync(tplDir, { recursive: true });
+  });
+
+  test("uses default directory when none specified", async () => {
+    const result = await listTemplates(undefined);
+    expect(Array.isArray(result)).toBe(true);
+  });
+});
+
+// ── applyTemplate ───────────────────────────────────────────────────────
+
+describe("applyTemplate", () => {
+  test("replaces {{input}} placeholder", () => {
+    const template = "Review this code:\n\n{{input}}\n\nProvide feedback.";
+    const result = applyTemplate(template, { input: "const x = 1;" });
+    expect(result).toBe(
+      "Review this code:\n\nconst x = 1;\n\nProvide feedback.",
+    );
+  });
+
+  test("replaces multiple variables", () => {
+    const template = "Hello {{name}}, your role is {{role}}.";
+    const result = applyTemplate(template, {
+      name: "Alice",
+      role: "developer",
+    });
+    expect(result).toBe("Hello Alice, your role is developer.");
+  });
+
+  test("leaves unreplaced variables as-is", () => {
+    const template = "Hello {{name}}, welcome to {{place}}.";
+    const result = applyTemplate(template, { name: "Bob" });
+    expect(result).toBe("Hello Bob, welcome to {{place}}.");
+  });
+
+  test("handles template with no variables", () => {
+    const template = "This is a plain template with no placeholders.";
+    const result = applyTemplate(template, { input: "unused" });
+    expect(result).toBe("This is a plain template with no placeholders.");
+  });
+
+  test("replaces multiple occurrences of the same variable", () => {
+    const template = "{{input}} and {{input}} again.";
+    const result = applyTemplate(template, { input: "hello" });
+    expect(result).toBe("hello and hello again.");
+  });
+
+  test("handles empty variables record", () => {
+    const template = "Nothing to replace: {{input}}.";
+    const result = applyTemplate(template, {});
+    expect(result).toBe("Nothing to replace: {{input}}.");
+  });
+
+  test("handles empty template string", () => {
+    const result = applyTemplate("", { input: "something" });
+    expect(result).toBe("");
+  });
+
+  test("replaces {{input}} with multi-line content", () => {
+    const template = "Code:\n{{input}}\nEnd.";
+    const multiLine = "line 1\nline 2\nline 3";
+    const result = applyTemplate(template, { input: multiLine });
+    expect(result).toBe("Code:\nline 1\nline 2\nline 3\nEnd.");
+  });
+});

--- a/src/completions.ts
+++ b/src/completions.ts
@@ -49,7 +49,7 @@ _${funcName}_completions() {
   COMPREPLY=()
   cur="\${COMP_WORDS[COMP_CWORD]}"
   prev="\${COMP_WORDS[COMP_CWORD-1]}"
-  opts="--model -m --system -s --role -r --roles --file -f --image -i --json -j --no-stream --no-cache --temperature -t --max-output-tokens --config -c --cost --markdown --chat --session -C --providers --completions --tools --mcp --no-update-check --version -V --help -h"
+  opts="--model -m --system -s --role -r --roles --template -T --templates --file -f --image -i --json -j --no-stream --no-cache --temperature -t --max-output-tokens --config -c --cost --markdown --chat --session -C --providers --completions --tools --mcp --no-update-check --version -V --help -h"
   providers="${providers}"
   subcommands="init config"
   config_subcommands="set show reset path"
@@ -85,7 +85,7 @@ _${funcName}_completions() {
       COMPREPLY=( $(compgen -W "${shells}" -- "\${cur}") )
       return 0
       ;;
-    -C|--session|-s|--system|-r|--role|-t|--temperature|--max-output-tokens)
+    -C|--session|-s|--system|-r|--role|-T|--template|-t|--temperature|--max-output-tokens)
       return 0
       ;;
   esac
@@ -128,6 +128,8 @@ _${funcName}() {
     '(-s --system)'{-s,--system}'[System prompt]:prompt:' \\
     '(-r --role)'{-r,--role}'[Role name from roles directory]:role:' \\
     '--roles[List available roles]' \\
+    '(-T --template)'{-T,--template}'[Template name from templates directory]:template:' \\
+    '--templates[List available templates]' \\
     '*'{-f,--file}'[Include file contents]:file:_files' \\
     '*'{-i,--image}'[Include image file (repeatable)]:file:_files' \\
     '(-j --json)'{-j,--json}'[Output full JSON response object]' \\
@@ -183,6 +185,8 @@ complete -c ${name} -s m -l model -d 'Model in provider/model-id format' -x -a '
 complete -c ${name} -s s -l system -d 'System prompt' -x
 complete -c ${name} -s r -l role -d 'Role name from roles directory' -x
 complete -c ${name} -l roles -d 'List available roles'
+complete -c ${name} -s T -l template -d 'Template name from templates directory' -x
+complete -c ${name} -l templates -d 'List available templates'
 complete -c ${name} -s f -l file -d 'Include file contents in prompt (repeatable)' -r -F
 complete -c ${name} -s i -l image -d 'Include image file (repeatable)' -r -F
 complete -c ${name} -s j -l json -d 'Output full JSON response object'
@@ -214,6 +218,8 @@ complete -c ai -s m -l model -d 'Model in provider/model-id format' -x -a '${SUP
 complete -c ai -s s -l system -d 'System prompt' -x
 complete -c ai -s r -l role -d 'Role name from roles directory' -x
 complete -c ai -l roles -d 'List available roles'
+complete -c ai -s T -l template -d 'Template name from templates directory' -x
+complete -c ai -l templates -d 'List available templates'
 complete -c ai -s f -l file -d 'Include file contents in prompt (repeatable)' -r -F
 complete -c ai -s i -l image -d 'Include image file (repeatable)' -r -F
 complete -c ai -s j -l json -d 'Output full JSON response object'

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,7 @@ import {
   resolveModel,
 } from "./provider.ts";
 import { StreamingMarkdownRenderer } from "./streaming-markdown.ts";
+import { applyTemplate, listTemplates, loadTemplate } from "./templates.ts";
 import { loadToolsConfig } from "./tools.ts";
 import { checkForUpdates } from "./update.ts";
 
@@ -100,6 +101,8 @@ export interface CLIOptions {
   completions?: string;
   session?: string;
   roles?: boolean;
+  template?: string;
+  templates?: boolean;
   cache: boolean;
   updateCheck?: boolean;
   tools?: string;
@@ -129,6 +132,8 @@ export const CLIOptionsSchema = z.object({
   completions: z.string().optional(),
   session: z.string().optional(),
   roles: z.boolean().optional(),
+  template: z.string().optional(),
+  templates: z.boolean().optional(),
   cache: z.boolean().optional().default(true),
   updateCheck: z.boolean().optional().default(true),
   tools: z.string().optional(),
@@ -616,6 +621,24 @@ async function runAction(
     return;
   }
 
+  // List available templates
+  if (opts.templates) {
+    const templates = await listTemplates();
+    const templatesDir = `~/${APP.configDirName}/templates/`;
+    if (templates.length === 0) {
+      console.log(
+        `No templates found. Create template files in ${templatesDir}`,
+      );
+      console.log(`Example: ${templatesDir}review.md`);
+    } else {
+      console.log("Available templates:");
+      for (const template of templates) {
+        console.log(`  - ${template}`);
+      }
+    }
+    return;
+  }
+
   const config = await loadConfig(opts.config);
 
   // Inject config API keys into process.env (env vars take precedence)
@@ -651,7 +674,24 @@ async function runAction(
     process.exit(1);
   }
 
-  const prompt = buildPrompt({ prompt: argPrompt, fileContent, stdinContent });
+  let prompt = buildPrompt({ prompt: argPrompt, fileContent, stdinContent });
+
+  // Apply template if --template is set
+  if (opts.template) {
+    const templateContent = await loadTemplate(opts.template);
+    if (templateContent) {
+      prompt = applyTemplate(templateContent, { input: prompt });
+    } else {
+      const templateFilename = opts.template.endsWith(".md")
+        ? opts.template
+        : `${opts.template}.md`;
+      console.error(
+        `Error: Template "${opts.template}" not found. Create it at ~/${APP.configDirName}/templates/${templateFilename} or run "ai-pipe --templates" to see available templates.`,
+      );
+      process.exit(1);
+    }
+  }
+
   if (!opts.chat && !prompt && images.length === 0) {
     await showUsage(mainCommand);
     process.exit(0);
@@ -954,6 +994,16 @@ export const mainCommand = defineCommand({
       description: `List available roles from ~/${APP.configDirName}/roles/`,
       default: false,
     },
+    template: {
+      type: "string",
+      alias: "T",
+      description: `Use a template from ~/${APP.configDirName}/templates/`,
+    },
+    templates: {
+      type: "boolean",
+      description: `List available templates from ~/${APP.configDirName}/templates/`,
+      default: false,
+    },
     completions: {
       type: "string",
       description: `Generate shell completions (${APP.supportedShells.join(", ")})`,
@@ -1017,6 +1067,8 @@ export const mainCommand = defineCommand({
       session: args.session,
       providers: args.providers,
       roles: args.roles,
+      template: args.template,
+      templates: args.templates,
       completions: args.completions,
       tools: args.tools,
       mcp: args.mcp,

--- a/src/templates.ts
+++ b/src/templates.ts
@@ -1,0 +1,88 @@
+import { basename, join } from "node:path";
+
+import { APP } from "./constants.ts";
+
+const HOME_DIR = Bun.env.HOME ?? Bun.env.USERPROFILE ?? "";
+const DEFAULT_CONFIG_DIR = join(HOME_DIR, APP.configDirName);
+const TEMPLATES_DIR = "templates";
+
+/**
+ * Load a template's content from a `.md` file in the templates directory.
+ *
+ * Template files are stored as `~/.ai-pipe/templates/<name>.md`. The template
+ * name is sanitized to prevent path traversal attacks. If the template name
+ * includes a `.md` extension, it is stripped to avoid double-extension issues.
+ *
+ * @param templateName - The template name (e.g., "review" or "review.md").
+ * @param configDir - Optional config directory. Defaults to `~/.ai-pipe/`.
+ * @returns The template file contents, or `null` if the template does not exist.
+ */
+export async function loadTemplate(
+  templateName: string,
+  configDir?: string,
+): Promise<string | null> {
+  const dir = configDir ?? DEFAULT_CONFIG_DIR;
+  // Sanitize templateName to prevent path traversal attacks
+  const sanitizedName = basename(templateName);
+  // Strip .md extension if present to avoid double extension
+  const nameWithoutExt = sanitizedName.replace(/\.md$/i, "");
+  const templatesPath = join(dir, TEMPLATES_DIR, nameWithoutExt);
+
+  // Only load .md template files
+  const mdFile = Bun.file(`${templatesPath}.md`);
+  if (await mdFile.exists()) {
+    return mdFile.text();
+  }
+
+  return null;
+}
+
+/**
+ * List all available template names from the templates directory.
+ *
+ * Scans `~/.ai-pipe/templates/` for `.md` files and returns their names
+ * (without extension), sorted alphabetically and deduplicated.
+ *
+ * @param configDir - Optional config directory. Defaults to `~/.ai-pipe/`.
+ * @returns A sorted array of template names, or an empty array if none exist.
+ */
+export async function listTemplates(configDir?: string): Promise<string[]> {
+  const dir = configDir ?? DEFAULT_CONFIG_DIR;
+  const templatesPath = join(dir, TEMPLATES_DIR);
+
+  try {
+    // Only scan for .md template files
+    const glob = new Bun.Glob("*.md");
+    const templateFiles = await Array.fromAsync(glob.scan(templatesPath));
+    const templates: string[] = templateFiles.map((path) =>
+      basename(path, ".md"),
+    );
+
+    return [...new Set(templates)].sort();
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Apply template substitutions: replace `{{variable}}` placeholders with values.
+ *
+ * Supports `{{input}}` as a special variable that gets the user's prompt text.
+ * Any `{{variable}}` placeholders without a matching key in `variables` are
+ * left as-is in the output.
+ *
+ * @param template - The template string containing `{{variable}}` placeholders.
+ * @param variables - A record of variable names to their replacement values.
+ * @returns The template string with matched placeholders replaced.
+ */
+export function applyTemplate(
+  template: string,
+  variables: Record<string, string>,
+): string {
+  return template.replace(/\{\{(\w+)\}\}/g, (match, key: string) => {
+    if (key in variables) {
+      return variables[key] as string;
+    }
+    return match;
+  });
+}


### PR DESCRIPTION
## Summary
- New `src/templates.ts` module for loading/listing/applying templates
- Templates stored as `.md` files in `~/.ai-pipe/templates/`
- `{{input}}` and `{{variable}}` placeholder substitution
- `--template/-T` flag to use a template, `--templates` to list them
- Shell completions for bash/zsh/fish
- 23 new tests (669 total)

## Usage
```bash
# Create a template
echo "Review this code: {{input}}" > ~/.ai-pipe/templates/review.md

# Use it
ai-pipe -T review -f main.go

# List templates
ai-pipe --templates
```

## Test plan
- [x] All 669 tests pass
- [x] Template loading, listing, and variable substitution tested