### PR TITLE
Add plugin system for extensible transforms

### DIFF
--- a/src/__tests__/plugins.test.ts
+++ b/src/__tests__/plugins.test.ts
@@ -1,0 +1,340 @@
+import { describe, expect, mock, test } from "bun:test";
+import {
+  type AfterResponseContext,
+  type BeforeRequestContext,
+  type Plugin,
+  PluginConfigSchema,
+  PluginManager,
+} from "../plugins.ts";
+
+// ── PluginConfigSchema ─────────────────────────────────────────────
+
+describe("PluginConfigSchema", () => {
+  test("validates correct config", () => {
+    const config = [
+      { path: "./my-plugin.ts", enabled: true },
+      { path: "./other-plugin.js", enabled: false, options: { key: "value" } },
+    ];
+    const result = PluginConfigSchema.safeParse(config);
+    expect(result.success).toBe(true);
+  });
+
+  test("defaults enabled to true when omitted", () => {
+    const config = [{ path: "./my-plugin.ts" }];
+    const result = PluginConfigSchema.safeParse(config);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data[0]?.enabled).toBe(true);
+    }
+  });
+
+  test("rejects invalid config (missing path)", () => {
+    const config = [{ enabled: true }];
+    const result = PluginConfigSchema.safeParse(config);
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects non-array config", () => {
+    const config = { path: "./my-plugin.ts", enabled: true };
+    const result = PluginConfigSchema.safeParse(config);
+    expect(result.success).toBe(false);
+  });
+
+  test("validates empty array", () => {
+    const result = PluginConfigSchema.safeParse([]);
+    expect(result.success).toBe(true);
+  });
+});
+
+// ── PluginManager ──────────────────────────────────────────────────
+
+describe("PluginManager", () => {
+  test("starts with no loaded plugins", () => {
+    const manager = new PluginManager();
+    expect(manager.getLoadedPlugins()).toEqual([]);
+  });
+
+  test("addPlugin adds a plugin", () => {
+    const manager = new PluginManager();
+    manager.addPlugin({ name: "test-plugin" });
+    expect(manager.getLoadedPlugins()).toEqual(["test-plugin"]);
+  });
+
+  test("getLoadedPlugins returns names with version", () => {
+    const manager = new PluginManager();
+    manager.addPlugin({ name: "alpha", version: "1.0.0" });
+    manager.addPlugin({ name: "beta" });
+    manager.addPlugin({ name: "gamma", version: "2.3.1" });
+    expect(manager.getLoadedPlugins()).toEqual([
+      "alpha v1.0.0",
+      "beta",
+      "gamma v2.3.1",
+    ]);
+  });
+
+  test("plugin without hooks is valid (name-only plugin)", () => {
+    const manager = new PluginManager();
+    const plugin: Plugin = { name: "noop-plugin" };
+    manager.addPlugin(plugin);
+    expect(manager.getLoadedPlugins()).toEqual(["noop-plugin"]);
+  });
+});
+
+// ── PluginManager.beforeRequest ────────────────────────────────────
+
+describe("PluginManager.beforeRequest", () => {
+  test("returns original prompt when no plugins have beforeRequest", async () => {
+    const manager = new PluginManager();
+    manager.addPlugin({ name: "noop" });
+    const result = await manager.beforeRequest({
+      prompt: "hello",
+      model: "openai/gpt-4o",
+    });
+    expect(result).toBe("hello");
+  });
+
+  test("transforms prompt with a single plugin", async () => {
+    const manager = new PluginManager();
+    manager.addPlugin({
+      name: "prefix-plugin",
+      beforeRequest: ({ prompt }) => `[PREFIX] ${prompt}`,
+    });
+    const result = await manager.beforeRequest({
+      prompt: "hello",
+      model: "openai/gpt-4o",
+    });
+    expect(result).toBe("[PREFIX] hello");
+  });
+
+  test("chains multiple plugins in order", async () => {
+    const manager = new PluginManager();
+    manager.addPlugin({
+      name: "first",
+      beforeRequest: ({ prompt }) => `[1:${prompt}]`,
+    });
+    manager.addPlugin({
+      name: "second",
+      beforeRequest: ({ prompt }) => `[2:${prompt}]`,
+    });
+    const result = await manager.beforeRequest({
+      prompt: "hello",
+      model: "openai/gpt-4o",
+    });
+    expect(result).toBe("[2:[1:hello]]");
+  });
+
+  test("passes model and system in context", async () => {
+    const manager = new PluginManager();
+    let capturedContext: BeforeRequestContext | undefined;
+    manager.addPlugin({
+      name: "spy",
+      beforeRequest: (ctx) => {
+        capturedContext = ctx;
+        return ctx.prompt;
+      },
+    });
+    await manager.beforeRequest({
+      prompt: "test",
+      model: "anthropic/claude-sonnet-4-5",
+      system: "Be helpful",
+    });
+    expect(capturedContext?.model).toBe("anthropic/claude-sonnet-4-5");
+    expect(capturedContext?.system).toBe("Be helpful");
+  });
+
+  test("supports async beforeRequest hooks", async () => {
+    const manager = new PluginManager();
+    manager.addPlugin({
+      name: "async-plugin",
+      beforeRequest: async ({ prompt }) => {
+        await new Promise((resolve) => setTimeout(resolve, 1));
+        return `async:${prompt}`;
+      },
+    });
+    const result = await manager.beforeRequest({
+      prompt: "hello",
+      model: "openai/gpt-4o",
+    });
+    expect(result).toBe("async:hello");
+  });
+});
+
+// ── PluginManager.afterResponse ────────────────────────────────────
+
+describe("PluginManager.afterResponse", () => {
+  test("returns original text when no plugins have afterResponse", async () => {
+    const manager = new PluginManager();
+    manager.addPlugin({ name: "noop" });
+    const result = await manager.afterResponse({
+      text: "world",
+      model: "openai/gpt-4o",
+    });
+    expect(result).toBe("world");
+  });
+
+  test("transforms text with a single plugin", async () => {
+    const manager = new PluginManager();
+    manager.addPlugin({
+      name: "upper",
+      afterResponse: ({ text }) => text.toUpperCase(),
+    });
+    const result = await manager.afterResponse({
+      text: "hello world",
+      model: "openai/gpt-4o",
+    });
+    expect(result).toBe("HELLO WORLD");
+  });
+
+  test("chains multiple plugins in order", async () => {
+    const manager = new PluginManager();
+    manager.addPlugin({
+      name: "wrap",
+      afterResponse: ({ text }) => `<${text}>`,
+    });
+    manager.addPlugin({
+      name: "upper",
+      afterResponse: ({ text }) => text.toUpperCase(),
+    });
+    const result = await manager.afterResponse({
+      text: "hello",
+      model: "openai/gpt-4o",
+    });
+    expect(result).toBe("<HELLO>");
+  });
+
+  test("passes model and usage in context", async () => {
+    const manager = new PluginManager();
+    let capturedContext: AfterResponseContext | undefined;
+    manager.addPlugin({
+      name: "spy",
+      afterResponse: (ctx) => {
+        capturedContext = ctx;
+        return ctx.text;
+      },
+    });
+    await manager.afterResponse({
+      text: "test",
+      model: "openai/gpt-4o",
+      usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+    });
+    expect(capturedContext?.model).toBe("openai/gpt-4o");
+    expect(capturedContext?.usage?.inputTokens).toBe(10);
+    expect(capturedContext?.usage?.outputTokens).toBe(5);
+    expect(capturedContext?.usage?.totalTokens).toBe(15);
+  });
+
+  test("supports async afterResponse hooks", async () => {
+    const manager = new PluginManager();
+    manager.addPlugin({
+      name: "async-plugin",
+      afterResponse: async ({ text }) => {
+        await new Promise((resolve) => setTimeout(resolve, 1));
+        return `async:${text}`;
+      },
+    });
+    const result = await manager.afterResponse({
+      text: "hello",
+      model: "openai/gpt-4o",
+    });
+    expect(result).toBe("async:hello");
+  });
+});
+
+// ── PluginManager.cleanup ──────────────────────────────────────────
+
+describe("PluginManager.cleanup", () => {
+  test("calls cleanup on all plugins", async () => {
+    const manager = new PluginManager();
+    const cleanupFn1 = mock(() => {});
+    const cleanupFn2 = mock(() => {});
+    manager.addPlugin({ name: "a", cleanup: cleanupFn1 });
+    manager.addPlugin({ name: "b", cleanup: cleanupFn2 });
+    await manager.cleanup();
+    expect(cleanupFn1).toHaveBeenCalledTimes(1);
+    expect(cleanupFn2).toHaveBeenCalledTimes(1);
+  });
+
+  test("does not fail when plugins have no cleanup hook", async () => {
+    const manager = new PluginManager();
+    manager.addPlugin({ name: "noop" });
+    await manager.cleanup(); // should not throw
+  });
+
+  test("supports async cleanup hooks", async () => {
+    const manager = new PluginManager();
+    let cleaned = false;
+    manager.addPlugin({
+      name: "async-cleanup",
+      cleanup: async () => {
+        await new Promise((resolve) => setTimeout(resolve, 1));
+        cleaned = true;
+      },
+    });
+    await manager.cleanup();
+    expect(cleaned).toBe(true);
+  });
+});
+
+// ── PluginManager.loadPlugins ──────────────────────────────────────
+
+describe("PluginManager.loadPlugins", () => {
+  test("throws when config file does not exist", async () => {
+    const manager = new PluginManager();
+    await expect(
+      manager.loadPlugins("/nonexistent/plugins.json"),
+    ).rejects.toThrow("Plugin config not found");
+  });
+});
+
+// ── Integration: full lifecycle ────────────────────────────────────
+
+describe("Plugin lifecycle", () => {
+  test("full lifecycle: init -> beforeRequest -> afterResponse -> cleanup", async () => {
+    const callOrder: string[] = [];
+    const plugin: Plugin = {
+      name: "lifecycle-plugin",
+      version: "1.0.0",
+      init: () => {
+        callOrder.push("init");
+      },
+      beforeRequest: ({ prompt }) => {
+        callOrder.push("beforeRequest");
+        return `modified:${prompt}`;
+      },
+      afterResponse: ({ text }) => {
+        callOrder.push("afterResponse");
+        return `result:${text}`;
+      },
+      cleanup: () => {
+        callOrder.push("cleanup");
+      },
+    };
+
+    const manager = new PluginManager();
+    // Simulate what loadPlugins does: call init, then add
+    if (plugin.init) plugin.init();
+    manager.addPlugin(plugin);
+
+    const prompt = await manager.beforeRequest({
+      prompt: "test",
+      model: "openai/gpt-4o",
+    });
+    expect(prompt).toBe("modified:test");
+
+    const text = await manager.afterResponse({
+      text: "response",
+      model: "openai/gpt-4o",
+    });
+    expect(text).toBe("result:response");
+
+    await manager.cleanup();
+
+    expect(callOrder).toEqual([
+      "init",
+      "beforeRequest",
+      "afterResponse",
+      "cleanup",
+    ]);
+    expect(manager.getLoadedPlugins()).toEqual(["lifecycle-plugin v1.0.0"]);
+  });
+});

--- a/src/completions.ts
+++ b/src/completions.ts
@@ -49,7 +49,7 @@ _${funcName}_completions() {
   COMPREPLY=()
   cur="\${COMP_WORDS[COMP_CWORD]}"
   prev="\${COMP_WORDS[COMP_CWORD-1]}"
-  opts="--model -m --system -s --role -r --roles --template -T --templates --file -f --image -i --json -j --format -F --no-stream --no-cache --temperature -t --max-output-tokens --config -c --cost --markdown --chat --session -C --budget -B --retries --providers --completions --tools --mcp --chain --verbose -v --no-update-check --version -V --help -h"
+  opts="--model -m --system -s --role -r --roles --template -T --templates --file -f --image -i --json -j --format -F --no-stream --no-cache --temperature -t --max-output-tokens --config -c --cost --markdown --chat --session -C --budget -B --retries --providers --completions --tools --mcp --chain --verbose -v --plugins -P --no-update-check --version -V --help -h"
   providers="${providers}"
   subcommands="init config session"
   config_subcommands="set show reset path"
@@ -83,7 +83,7 @@ _${funcName}_completions() {
       compopt -o nospace
       return 0
       ;;
-    -f|--file|-i|--image|--tools|--mcp|--chain)
+    -f|--file|-i|--image|--tools|--mcp|--chain|-P|--plugins)
       COMPREPLY=( $(compgen -f -- "\${cur}") )
       return 0
       ;;
@@ -175,6 +175,7 @@ _${funcName}() {
     '--mcp[Path to MCP server configuration file (JSON)]:file:_files' \\
     '--chain[Path to chain config JSON file]:file:_files' \\
     '(-v --verbose)'{-v,--verbose}'[Show intermediate chain outputs on stderr]' \\
+    '(-P --plugins)'{-P,--plugins}'[Path to plugins configuration file (JSON)]:file:_files' \\
     '--no-update-check[Disable update notifications]' \\
     '(-V --version)'{-V,--version}'[Print version]' \\
     '(-h --help)'{-h,--help}'[Print help]' \\
@@ -244,6 +245,7 @@ complete -c ${name} -l tools -d 'Path to tools configuration file (JSON)' -r -F
 complete -c ${name} -l mcp -d 'Path to MCP server configuration file (JSON)' -r -F
 complete -c ${name} -l chain -d 'Path to chain config JSON file' -r -F
 complete -c ${name} -s v -l verbose -d 'Show intermediate chain outputs on stderr'
+complete -c ${name} -s P -l plugins -d 'Path to plugins configuration file (JSON)' -r -F
 complete -c ${name} -l no-update-check -d 'Disable update notifications'
 complete -c ${name} -s V -l version -d 'Print version'
 complete -c ${name} -s h -l help -d 'Print help'
@@ -286,6 +288,7 @@ complete -c ai -l tools -d 'Path to tools configuration file (JSON)' -r -F
 complete -c ai -l mcp -d 'Path to MCP server configuration file (JSON)' -r -F
 complete -c ai -l chain -d 'Path to chain config JSON file' -r -F
 complete -c ai -s v -l verbose -d 'Show intermediate chain outputs on stderr'
+complete -c ai -s P -l plugins -d 'Path to plugins configuration file (JSON)' -r -F
 complete -c ai -s V -l version -d 'Print version'
 complete -c ai -s h -l help -d 'Print help'`;
 }

--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -1,0 +1,166 @@
+import { z } from "zod";
+
+/**
+ * Context passed to the beforeRequest plugin hook.
+ */
+export interface BeforeRequestContext {
+  prompt: string;
+  model: string;
+  system?: string;
+}
+
+/**
+ * Context passed to the afterResponse plugin hook.
+ */
+export interface AfterResponseContext {
+  text: string;
+  model: string;
+  usage?: { inputTokens?: number; outputTokens?: number; totalTokens?: number };
+}
+
+/**
+ * Plugin hook interface — plugins can implement any of these hooks.
+ *
+ * At minimum, a plugin must export a `name` property.
+ */
+export interface Plugin {
+  name: string;
+  version?: string;
+
+  /** Transform the prompt before sending to the model */
+  beforeRequest?: (context: BeforeRequestContext) => Promise<string> | string;
+
+  /** Transform the response text after receiving from the model */
+  afterResponse?: (context: AfterResponseContext) => Promise<string> | string;
+
+  /** Called when the plugin is loaded */
+  init?: () => Promise<void> | void;
+
+  /** Called when the CLI exits */
+  cleanup?: () => Promise<void> | void;
+}
+
+/** Schema for plugin config in ~/.ai-pipe/plugins.json */
+export const PluginConfigSchema = z.array(
+  z.object({
+    path: z.string(),
+    enabled: z.boolean().default(true),
+    options: z.record(z.string(), z.unknown()).optional(),
+  }),
+);
+
+export type PluginConfig = z.infer<typeof PluginConfigSchema>;
+
+/**
+ * Plugin manager that loads and runs plugins.
+ *
+ * Plugins are loaded from a JSON config file and executed in order.
+ * Each plugin can hook into the request/response lifecycle to transform
+ * prompts and outputs.
+ */
+export class PluginManager {
+  private plugins: Plugin[] = [];
+
+  /**
+   * Load plugins from a JSON config file.
+   *
+   * The config file should contain an array of plugin entries, each with
+   * a `path` to the plugin module, an `enabled` flag, and optional `options`.
+   * Disabled plugins are skipped. Each loaded plugin's `init` hook is called
+   * if present.
+   *
+   * @param configPath - Absolute or relative path to the plugins config JSON file.
+   * @throws If the config file does not exist or fails validation.
+   * @throws If a plugin module does not export a `name` property.
+   */
+  async loadPlugins(configPath: string): Promise<void> {
+    const file = Bun.file(configPath);
+    if (!(await file.exists())) {
+      throw new Error(`Plugin config not found: ${configPath}`);
+    }
+    const raw = await file.json();
+    const configs = PluginConfigSchema.parse(raw);
+
+    for (const config of configs) {
+      if (!config.enabled) continue;
+      const plugin = await import(config.path);
+      const p: Plugin = plugin.default || plugin;
+      if (!p.name) {
+        throw new Error(
+          `Plugin at ${config.path} must export a 'name' property`,
+        );
+      }
+      if (p.init) await p.init();
+      this.plugins.push(p);
+    }
+  }
+
+  /**
+   * Add a plugin instance directly (useful for testing).
+   *
+   * @param plugin - A plugin object conforming to the Plugin interface.
+   */
+  addPlugin(plugin: Plugin): void {
+    this.plugins.push(plugin);
+  }
+
+  /**
+   * Run all beforeRequest hooks in order, transforming the prompt.
+   *
+   * Each plugin's beforeRequest hook receives the current prompt and can
+   * return a modified version. Plugins are called in the order they were loaded.
+   *
+   * @param context - The before-request context containing prompt, model, and system.
+   * @returns The transformed prompt string.
+   */
+  async beforeRequest(context: BeforeRequestContext): Promise<string> {
+    let prompt = context.prompt;
+    for (const plugin of this.plugins) {
+      if (plugin.beforeRequest) {
+        prompt = await plugin.beforeRequest({ ...context, prompt });
+      }
+    }
+    return prompt;
+  }
+
+  /**
+   * Run all afterResponse hooks in order, transforming the response text.
+   *
+   * Each plugin's afterResponse hook receives the current text and can
+   * return a modified version. Plugins are called in the order they were loaded.
+   *
+   * @param context - The after-response context containing text, model, and usage.
+   * @returns The transformed response text.
+   */
+  async afterResponse(context: AfterResponseContext): Promise<string> {
+    let text = context.text;
+    for (const plugin of this.plugins) {
+      if (plugin.afterResponse) {
+        text = await plugin.afterResponse({ ...context, text });
+      }
+    }
+    return text;
+  }
+
+  /**
+   * Call all plugin cleanup hooks.
+   *
+   * Should be called when the CLI exits to allow plugins to release resources.
+   */
+  async cleanup(): Promise<void> {
+    for (const plugin of this.plugins) {
+      if (plugin.cleanup) await plugin.cleanup();
+    }
+  }
+
+  /**
+   * Get a list of loaded plugin names with optional version info.
+   *
+   * @returns An array of strings like "my-plugin v1.0.0" or "my-plugin".
+   */
+  getLoadedPlugins(): string[] {
+    return this.plugins.map(
+      (p) => `${p.name}${p.version ? ` v${p.version}` : ""}`,
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- New `src/plugins.ts` with `PluginManager` class
- Plugins can hook into `beforeRequest` and `afterResponse` to transform prompts/outputs
- `--plugins/-P <path>` flag to load plugin config
- Auto-loads `~/.ai-pipe/plugins.json` if it exists
- 24 new tests

## Usage
```bash
ai-pipe --plugins ./plugins.json "hello"
```

## Test plan
- [x] All 776 tests pass
- [x] Plugin lifecycle, chaining, async hooks tested