### PR TITLE
🐛 Fix global install: add bun shebang to entry point

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env bun
 import { join } from "node:path";
 import {
   generateText,


### PR DESCRIPTION
## Summary
- Adds `#!/usr/bin/env bun` shebang to `src/index.ts` so global installs work correctly
- Without this, `bun install -g ai-pipe` creates a symlink to raw TypeScript that the shell tries to execute as bash, producing `import: command not found` errors

## Root Cause
The `bin` field in package.json points to `src/index.ts` directly. When Bun installs globally, it symlinks `~/.bun/bin/ai -> node_modules/ai-pipe/src/index.ts`. Without a shebang, the OS defaults to `/bin/sh` which can't parse TypeScript.

## Test plan
- [x] All 808 tests pass
- [ ] `bun install -g ai-pipe` then `ai --version` works