### PR TITLE
🐛 Fix streaming markdown text duplication

### DIFF
--- a/src/streaming-markdown.ts
+++ b/src/streaming-markdown.ts
@@ -4,6 +4,10 @@ import { renderMarkdown } from "./markdown.ts";
 /** Debounce interval in milliseconds for progressive rendering. */
 const RENDER_DEBOUNCE_MS = 100;
 
+/** Matches ANSI SGR escape sequences (zero visual width in terminal). */
+// biome-ignore lint/suspicious/noControlCharactersInRegex: ANSI escape codes are intentional
+const ANSI_RE = /\x1b\[[0-9;]*m/g;
+
 /**
  * Progressive streaming markdown renderer for terminal output.
  *
@@ -35,6 +39,26 @@ export class StreamingMarkdownRenderer {
   }
 
   /**
+   * Count visual terminal lines the cursor moved down after writing text.
+   * Accounts for terminal line wrapping (long lines that exceed terminal
+   * width) and ANSI escape codes (which are zero-width).
+   */
+  private countVisualLines(text: string): number {
+    const cols = process.stdout.columns || 80;
+    const lines = text.split("\n");
+    // Start with the number of explicit newlines
+    let count = lines.length - 1;
+    // Add extra lines caused by terminal wrapping
+    for (const line of lines) {
+      const visual = line.replace(ANSI_RE, "").length;
+      if (visual > cols) {
+        count += Math.ceil(visual / cols) - 1;
+      }
+    }
+    return count;
+  }
+
+  /**
    * Clear the previously rendered output and re-render the full buffer.
    *
    * Uses ANSI escape codes to move the cursor up and clear lines, then
@@ -43,8 +67,9 @@ export class StreamingMarkdownRenderer {
    */
   private render(): void {
     // Move cursor up to overwrite previous output (skip on first render)
+    // \r ensures we're at column 0 before clearing
     if (this.lineCount > 0) {
-      process.stdout.write(`\x1b[${this.lineCount}A\x1b[J`);
+      process.stdout.write(`\x1b[${this.lineCount}A\r\x1b[J`);
     }
 
     // Complete incomplete markdown syntax before rendering
@@ -52,9 +77,8 @@ export class StreamingMarkdownRenderer {
     const rendered = renderMarkdown(completed);
     process.stdout.write(rendered);
 
-    // Count lines for the next clear cycle
-    this.lineCount = rendered.split("\n").length - 1;
-    if (this.lineCount < 0) this.lineCount = 0;
+    // Count visual lines for the next clear cycle
+    this.lineCount = this.countVisualLines(rendered);
   }
 
   /**
@@ -68,7 +92,7 @@ export class StreamingMarkdownRenderer {
     }
     // Final render uses the raw buffer (stream is complete, no fixup needed)
     if (this.lineCount > 0) {
-      process.stdout.write(`\x1b[${this.lineCount}A\x1b[J`);
+      process.stdout.write(`\x1b[${this.lineCount}A\r\x1b[J`);
     }
     const rendered = renderMarkdown(this.buffer);
     process.stdout.write(rendered);


### PR DESCRIPTION
## Summary

Fixes text duplication/repetition in `--chat --markdown` mode where the streaming renderer would show the same text repeated many times before eventually settling.

## Root cause

`StreamingMarkdownRenderer.render()` counts lines to clear by splitting on `\n`, but this only counts explicit newlines — not visual line wraps caused by text exceeding terminal width. When a rendered line wraps (e.g. a 200-char line in an 80-col terminal takes 3 visual lines), the cursor-up escape only moves up 1 line instead of 3, leaving stale text visible. Each re-render compounds the problem.

## Fix

- Add `countVisualLines()` that accounts for terminal width (`process.stdout.columns`) and strips ANSI escape codes (which are zero-width) before measuring
- Add `\r` (carriage return) before `\x1b[J` (clear to end of screen) to ensure clearing starts from column 0

## Test plan

- [x] TypeScript typecheck passes
- [x] All 43 markdown + streaming-markdown tests pass
- [ ] Manual: `ai-pipe --chat --markdown` — verify no text duplication on long responses