### PR TITLE
⬆️ Update Bun version requirement to 1.3.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,9 +88,9 @@
   "peerDependencies": {
     "typescript": "^5.9.3"
   },
-  "packageManager": "bun@1.3.8",
+  "packageManager": "bun@1.3.10",
   "engines": {
-    "bun": "^1.3.8",
+    "bun": "^1.3.10",
     "node": ">=22.0.0"
   }
 }


### PR DESCRIPTION
Updates minimum Bun version to support Bun.markdown.render() API.\n\n## Problem\nPackage uses Bun.markdown.render() which was introduced in Bun 1.3.10.\nCurrent requirement of 1.3.8 causes 43 tests to fail with:\nTypeError: undefined is not an object (evaluating Bun.markdown.render)\n\n## Solution\n- Updated packageManager from bun@1.3.8 to bun@1.3.10\n- Updated engines.bun from ^1.3.8 to ^1.3.10\n\n## Impact\nAfter upgrading to Bun 1.3.10+, all 841 tests should pass.